### PR TITLE
Use JSON-mode request serialization

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -1,0 +1,109 @@
+# Serialization Guidelines
+
+These guidelines define how domain models move between internal Python code and
+external boundaries such as HTTP requests, JSON, persisted fixtures, and API
+responses.
+
+## Core Rule
+
+Use rich domain objects inside the application. Use primitive JSON-compatible
+values at serialization boundaries.
+
+Internal code may use types such as `Amount`, `date`, `Enum`, `Option`, and
+`Equity` when they make the domain model clearer. Serialized output should not
+contain those objects as dictionary keys or scalar values. It should use strings,
+numbers, booleans, nulls, lists, and dictionaries with string keys.
+
+## Dictionary Keys
+
+Python dictionaries can use any hashable object as a key, but JSON object keys
+are strings. Pydantic serialization can also recursively convert model objects
+into dictionaries, which makes model objects unsafe as serialized dictionary
+keys.
+
+Follow these conventions:
+
+- `Amount` keys serialize with `str(amount)`, for example `"25.00 USD"`.
+- `date` keys serialize with `date.isoformat()`, for example `"2026-01-16"`.
+- `Enum` keys serialize with `enum.value`, for example `"etrade"` or `"PUT"`.
+- Pydantic model instances must never appear as keys in `model_dump()` output.
+- Validators should parse serialized keys back into rich internal keys when the
+  model is validated.
+
+Use the helpers in `fianchetto_tradebot.common_models.serialization` for shared
+key conversions instead of reimplementing parsing and formatting in each model.
+
+## Pydantic Dumps
+
+Use the dump mode that matches the boundary:
+
+- Internal inspection or rich Python round trips: `model_dump()`.
+- HTTP request bodies, JSON payloads, logs intended as JSON, and persisted JSON:
+  `model_dump(mode="json")` or `model_dump_json()`.
+
+Client code that passes payloads to `requests` should use
+`model_dump(mode="json")`. This ensures nested dates and enums are converted
+before the HTTP library sees the payload.
+
+## Model Serializer Pattern
+
+For a model field with rich dictionary keys:
+
+1. Add a `field_serializer` that emits primitive string keys.
+2. Add a matching `field_validator(..., mode="before")` that accepts either the
+   rich internal key type or the serialized string form.
+3. Keep the field annotation in the rich internal shape if that is what the rest
+   of the application uses.
+
+Example shape:
+
+```python
+class Example(BaseModel):
+    prices: dict[Amount, dict[date, Price]]
+
+    @field_serializer("prices", when_used="always")
+    def serialize_prices(self, prices):
+        return {
+            serialize_amount_key(amount): {
+                serialize_date_key(expiry): price
+                for expiry, price in expiry_map.items()
+            }
+            for amount, expiry_map in prices.items()
+        }
+
+    @field_validator("prices", mode="before")
+    @classmethod
+    def deserialize_prices(cls, value):
+        if isinstance(value, dict):
+            return {
+                deserialize_amount_key(amount): {
+                    deserialize_date_key(expiry): price
+                    for expiry, price in expiry_map.items()
+                }
+                for amount, expiry_map in value.items()
+            }
+        return value
+```
+
+## Testing Expectations
+
+Tests for serialized models should assert the contract, not only that dumping
+does not crash.
+
+For models with custom serialization:
+
+- Assert all serialized dictionary keys are strings.
+- Assert important serialized keys have the expected exact value.
+- Assert `Model.model_validate(model.model_dump())` rebuilds rich internal keys.
+- Assert `Model.model_validate_json(model.model_dump_json())` round-trips.
+- For HTTP clients, assert outbound request JSON contains no `date`, `Enum`, or
+  `BaseModel` instances.
+
+## Current Examples
+
+The current canonical examples are:
+
+- `Chain`: serializes nested `Amount` and `date` keys.
+- `Portfolio`: serializes nested `date`, `Amount`, and `OptionType` keys.
+- `ListManagedExecutionsRequest`: serializes `Brokerage` keys.
+- `Client.post` and `Client.put`: serialize request bodies in Pydantic JSON mode.

--- a/src/fianchetto_tradebot/client/client.py
+++ b/src/fianchetto_tradebot/client/client.py
@@ -199,11 +199,11 @@ class Client:
         url = self._format_path(path, base_uri, path_params)
         if hasattr(self, 'session'):
             response = self.session.post(
-                url, json=request_body.model_dump(), timeout=self.timeout
+                url, json=request_body.model_dump(mode="json"), timeout=self.timeout
             )
         else:
             response = requests.post(
-                url, json=request_body.model_dump(), timeout=self.timeout
+                url, json=request_body.model_dump(mode="json"), timeout=self.timeout
             )
         response.raise_for_status()
         return response_model.model_validate(response.json())
@@ -219,11 +219,11 @@ class Client:
         url = self._format_path(path, base_uri, path_params)
         if hasattr(self, 'session'):
             response = self.session.put(
-                url, json=request_body.model_dump(), timeout=self.timeout
+                url, json=request_body.model_dump(mode="json"), timeout=self.timeout
             )
         else:
             response = requests.put(
-                url, json=request_body.model_dump(), timeout=self.timeout
+                url, json=request_body.model_dump(mode="json"), timeout=self.timeout
             )
         response.raise_for_status()
         return response_model.model_validate(response.json())

--- a/src/fianchetto_tradebot/common_models/managed_executions/list_managed_executions_request.py
+++ b/src/fianchetto_tradebot/common_models/managed_executions/list_managed_executions_request.py
@@ -1,7 +1,24 @@
+from pydantic import field_serializer, field_validator
+
 from fianchetto_tradebot.common_models.api.request import Request
 from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.common_models.serialization import deserialize_enum_key, serialize_enum_key
 
 
 class ListManagedExecutionsRequest(Request):
     accounts: dict[Brokerage, str]
     # TODO: Filter for active vs. finished, cancelled, etc.
+
+    @field_serializer("accounts", when_used="always")
+    def serialize_accounts(self, accounts: dict[Brokerage, str]):
+        return {serialize_enum_key(brokerage): account_id for brokerage, account_id in accounts.items()}
+
+    @field_validator("accounts", mode="before")
+    @classmethod
+    def deserialize_accounts(cls, value):
+        if isinstance(value, dict):
+            return {
+                deserialize_enum_key(Brokerage, brokerage): account_id
+                for brokerage, account_id in value.items()
+            }
+        return value

--- a/tests/common/test_request_serialization.py
+++ b/tests/common/test_request_serialization.py
@@ -1,0 +1,127 @@
+from datetime import date
+from enum import Enum
+
+from pydantic import BaseModel
+
+from fianchetto_tradebot.client.client import Client
+from fianchetto_tradebot.common_models.api.orders.order_metadata import OrderMetadata
+from fianchetto_tradebot.common_models.api.orders.preview_order_request import PreviewOrderRequest
+from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.common_models.finance.amount import Amount
+from fianchetto_tradebot.common_models.finance.currency import Currency
+from fianchetto_tradebot.common_models.finance.equity import Equity
+from fianchetto_tradebot.common_models.finance.exercise_style import ExerciseStyle
+from fianchetto_tradebot.common_models.finance.option import Option
+from fianchetto_tradebot.common_models.finance.option_type import OptionType
+from fianchetto_tradebot.common_models.managed_executions.list_managed_executions_request import (
+    ListManagedExecutionsRequest,
+)
+from fianchetto_tradebot.common_models.order.action import Action
+from fianchetto_tradebot.common_models.order.expiry.good_until_cancelled import GoodUntilCancelled
+from fianchetto_tradebot.common_models.order.order import Order
+from fianchetto_tradebot.common_models.order.order_line import OrderLine
+from fianchetto_tradebot.common_models.order.order_price import OrderPrice
+from fianchetto_tradebot.common_models.order.order_price_type import OrderPriceType
+
+
+class _OkResponse(BaseModel):
+    ok: bool
+
+
+class _Response:
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"ok": True}
+
+
+class _RecordingSession:
+    def __init__(self):
+        self.last_json = None
+
+    def post(self, _url, json, timeout):
+        self.last_json = json
+        return _Response()
+
+    def put(self, _url, json, timeout):
+        self.last_json = json
+        return _Response()
+
+
+def _assert_json_compatible(value):
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            assert isinstance(key, str), f"Expected JSON object key to be str, got {type(key)}: {key!r}"
+            _assert_json_compatible(nested_value)
+    elif isinstance(value, list):
+        for nested_value in value:
+            _assert_json_compatible(nested_value)
+    else:
+        assert value is None or isinstance(value, (str, int, float, bool))
+        assert not isinstance(value, (date, Enum, BaseModel))
+
+
+def _preview_option_order_request() -> PreviewOrderRequest:
+    option = Option(
+        equity=Equity(ticker="GE"),
+        type=OptionType.PUT,
+        strike=Amount(whole=10, part=0, currency=Currency.US_DOLLARS),
+        expiry=date(2026, 1, 16),
+        style=ExerciseStyle.AMERICAN,
+    )
+    order_line = OrderLine(tradable=option, action=Action.BUY, quantity=1)
+    order_price = OrderPrice(
+        order_price_type=OrderPriceType.LIMIT,
+        price=Amount(whole=1, part=25, currency=Currency.US_DOLLARS),
+    )
+    order = Order(expiry=GoodUntilCancelled(), order_lines=[order_line], order_price=order_price)
+    return PreviewOrderRequest(
+        order_metadata=OrderMetadata(
+            order_type=order.get_order_type(),
+            account_id="abc123",
+            client_order_id="client-1",
+        ),
+        order=order,
+    )
+
+
+def test_list_managed_executions_request_serializes_brokerage_keys_as_strings():
+    request = ListManagedExecutionsRequest(accounts={Brokerage.ETRADE: "acct-1"})
+
+    as_dict = request.model_dump()
+
+    assert as_dict == {"accounts": {"etrade": "acct-1"}}
+    _assert_json_compatible(as_dict)
+    assert ListManagedExecutionsRequest.model_validate(as_dict).accounts == {
+        Brokerage.ETRADE: "acct-1"
+    }
+    assert ListManagedExecutionsRequest.model_validate_json(request.model_dump_json()).accounts == {
+        Brokerage.ETRADE: "acct-1"
+    }
+
+
+def test_client_post_serializes_request_body_in_json_mode():
+    client = Client(Brokerage.ETRADE)
+    client.session = _RecordingSession()
+
+    client.post("", "", _preview_option_order_request(), _OkResponse)
+
+    payload = client.session.last_json
+    _assert_json_compatible(payload)
+    assert payload["order_metadata"]["order_type"] == "OPTN"
+    assert payload["order"]["order_lines"][0]["tradable"]["expiry"] == "2026-01-16"
+    assert payload["order"]["order_lines"][0]["tradable"]["type"] == "PUT"
+    assert payload["order"]["order_price"]["price"]["currency"] == "USD"
+
+
+def test_client_put_serializes_request_body_in_json_mode():
+    client = Client(Brokerage.ETRADE)
+    client.session = _RecordingSession()
+
+    client.put("", "", _preview_option_order_request(), _OkResponse)
+
+    payload = client.session.last_json
+    _assert_json_compatible(payload)
+    assert payload["order_metadata"]["order_type"] == "OPTN"
+    assert payload["order"]["order_lines"][0]["tradable"]["expiry"] == "2026-01-16"


### PR DESCRIPTION
## Summary
- send client POST/PUT request bodies with Pydantic JSON-mode serialization
- serialize ListManagedExecutionsRequest brokerage keys explicitly as strings
- add regression tests for JSON-compatible request payloads and enum-key round trips

## Tests
- PYTHONPATH=src:tests /tmp/tradebot-pydantic-213/bin/python -m pytest tests/common/test_request_serialization.py
- PYTHONPATH=src:tests /tmp/tradebot-pydantic-213/bin/python -m pytest