### PR TITLE
FIA-131: Ignore local generated folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ src/fianchetto_tradebot/server/common/api/scripts/integration_test_properties.in
 *.egg-info
 **/__pycache__
 .venv
+.idea/
+.pytest_cache/
+dist/
+outputs/


### PR DESCRIPTION
## Summary
- ignore local IDE metadata and generated folders
- add top-level `.idea/`, `.pytest_cache/`, `dist/`, and `outputs/` to `.gitignore`

## Verification
- `git check-ignore -v .idea dist outputs .pytest_cache`
- `git status --short --ignored` shows those folders as ignored, not untracked

Linear: FIA-131
