### PR TITLE
FIA-132: Update TradeBot README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,148 @@
-# TRADEBOT
+# TradeBot
 
-## Purpose
+TradeBot is an open-source Python platform for researching and executing systematic equity and options strategies across multiple retail brokerages. It provides common abstractions for market data, portfolio state, and order management so that strategy and execution logic can operate independently of brokerage-specific APIs.
 
-Use this library to execute trading strategies across various brokerages, including E*Trade, Schwab, and Interactive Brokers (IKBR).
+The platform includes services for retrieving quotes and option chains, identifying trading opportunities, constructing strategy candidates, submitting and managing orders, and surfacing execution state. Current development focuses on E\*Trade and Schwab integrations, with an architecture designed to support additional brokerages.
 
-## Get Started!
-### Pull down the package
-`$> pip install fianchetto-tradebot`
+> **Project status:** TradeBot is under active development and should be treated as experimental software. It is not investment advice and should not be used to place live orders without independent review, testing, and appropriate safeguards.
 
-### Using the package
-`from fianchetto_tradebot.oex.oex_service import OexService`
+## Key capabilities
 
-### Pull down the quickstart package
-`$> pip install fianchetto-tradebot-quickstart`
+- Common models for equities, options, orders, accounts, portfolios, and brokerage responses
+- Brokerage-independent interfaces for quotes, portfolio state, and order workflows
+- Equity quotes and option-chain retrieval
+- Strategy research components, including calendar-spread construction and same-day-expiry analysis
+- Order preview, submission, cancellation, and status retrieval
+- Managed execution workers that monitor working orders and apply configurable execution tactics
+- Incremental limit-price adjustment for eligible orders
+- REST services and a Python client for programmatic access
+- Unit, component, and brokerage integration tests
+- Installable Python packages for the core platform and quickstart workflows
 
-## Components
+## Architecture
+
+TradeBot is organized into modular services with shared financial models and brokerage adapters.
+
+```mermaid
+flowchart TD
+    Strategy["User strategy"] --> Trident["Trident: opportunity research"]
+    Trident --> Quotes["Quotes: market data"]
+    Trident --> OEX["OEX: order execution"]
+    Quotes --> Adapters["Brokerage adapters"]
+    OEX --> Adapters
+    Adapters --> Brokers["E*Trade / Schwab"]
+    OEX --> Helm["Helm: execution visibility"]
+```
 
 ### Trident
 
-Trade Identifier Service - service for identifying trading opportunities by scanning markets using user-supplied strategies.
-
-### Oex
-
-Order Executor Service - service for executing user-supplied orders
+The Trade Identifier Service scans market data using user-supplied research or strategy logic. Its components include option analysis and construction of candidate trades such as calendar spreads.
 
 ### Quotes
 
-Quote Service - service for getting live market info for options and equities from the various brokerages. May be expanded to Futures later.
+The Quote Service retrieves live equity and options market data through brokerage-specific adapters while exposing common request and response models to downstream code.
+
+### OEX
+
+The Order Executor Service supports order preview, placement, cancellation, status retrieval, and managed execution. Execution tactics can monitor working orders and adjust limit prices according to configurable rules.
 
 ### Helm
 
-Visiblity - service for surfacing the current state of all trades and trading strategies
-
-### Test
-
-Various integration and component tests.
-
-### Scripts
-
-Various integration test scripts and utility scripts that are used on a one-off, or reference basis.
+Helm is the visibility layer for surfacing the state of trading strategies, orders, and managed executions.
 
 ### Common
 
-Contains basic primitives such as financial instrument definitions used throughout TradeBot, libraries for connecting to brokerages, and other shared logic.
+Shared modules define financial instruments, brokerage interfaces, serialized API models, service primitives, and reusable connectivity logic.
 
-## Liability
-This project makes no guarantees of any kind, explicit, or implicit, for its correctness, safety, or even suitability for its purpose. Contributors and users should use their best care and judgement when using this project.
-While care is taken to build a robust, scalable, and correct system, use is completely at their own risk.
+## Brokerage support
+
+Brokerage capabilities are evolving and may not be uniform across integrations.
+
+| Brokerage | Market data | Portfolio/account data | Order workflows | Status |
+| --- | --- | --- | --- | --- |
+| E\*Trade | Implemented | Implemented | Implemented | Primary integration |
+| Schwab | In development | In development | In development | Adapter scaffold |
+| Interactive Brokers | Planned | Planned | Planned | Roadmap |
+
+Before relying on a capability, review the relevant adapter and tests in the repository. Broker APIs and authentication requirements can change independently of TradeBot.
+
+## Installation
+
+TradeBot requires Python 3.14.
+
+Install the core package:
+
+```bash
+pip install fianchetto-tradebot
+```
+
+Install the quickstart package:
+
+```bash
+pip install fianchetto-tradebot-quickstart
+```
+
+## Basic usage
+
+The Python client and service modules provide programmatic access to brokerage, quote, portfolio, and order functionality. Brokerage credentials and configuration are required before making authenticated requests.
+
+```python
+from fianchetto_tradebot.client.client import Client
+from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+
+# Connect to locally running TradeBot services using the E*Trade adapter.
+# See the developer setup and brokerage configuration guides before use.
+client = Client(Brokerage.ETRADE)
+accounts = client.get_accounts()
+```
+
+For local environment setup and brokerage configuration, see:
+
+- [`dev_get_started_guides/set_up_local_env.MD`](dev_get_started_guides/set_up_local_env.MD)
+- [`dev_get_started_guides/exchange_setup.MD`](dev_get_started_guides/exchange_setup.MD)
+- [`docs/serialization.md`](docs/serialization.md)
+
+> The client API is evolving. Consult the source and tests for the current constructor and supported operations.
+
+## Development
+
+Clone the repository and install the package with development dependencies:
+
+```bash
+git clone https://github.com/fianchetto-labs/tradebot.git
+cd tradebot
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+Run the test suite:
+
+```bash
+pytest
+```
+
+Brokerage integration tests require separate credentials and configuration. Do not commit access tokens, private keys, account identifiers, or other secrets.
+
+## Contributing
+
+Contributions are welcome. Useful areas include:
+
+- Additional brokerage adapters
+- Market-data normalization
+- Execution tactics and risk controls
+- Strategy research components
+- Test coverage and brokerage simulators
+- Documentation and reproducible local development
+
+Before opening a pull request, add or update tests for behavioral changes and clearly identify any brokerage-specific assumptions.
+
+## Safety and liability
+
+Trading software can lose money through software defects, stale or incorrect market data, unexpected brokerage behavior, partial fills, rejected orders, network failures, or flawed strategy assumptions.
+
+TradeBot makes no guarantees, express or implied, regarding correctness, safety, profitability, availability, or fitness for any purpose. Users and contributors are responsible for independently reviewing and testing the software and for complying with all applicable brokerage agreements, exchange rules, and laws. Use of this project is entirely at the user's own risk.
+
+## License
+
+TradeBot is licensed under the [GNU Affero General Public License v3.0](LICENSE).


### PR DESCRIPTION
## Summary
- replace the sparse README with the updated TradeBot overview
- add project status, capabilities, architecture, brokerage support, installation, usage, development, contributing, safety/liability, and license sections
- link existing developer setup, exchange setup, and serialization docs
- normalize the clone URL to the canonical `fianchetto-labs/tradebot` repository path
- standardize Interactive Brokers references on `IBKR`, including source package paths and comments
- keep backward-compatible enum aliases for the previous `IKBR` spelling

## Suggestions / follow-ups
- Add CI/package/version badges once release conventions settle.
- Revisit the brokerage support matrix periodically as Schwab and IBKR support changes.
- Add a runnable quickstart example once the local service startup path is fully documented.
- Consider linking to hosted docs if the README grows beyond a good first-page overview.

## Verification
- Confirmed linked files exist locally: setup guide, exchange setup guide, serialization docs, and license.
- `PYTHONPATH=src:tests /tmp/tradebot-pydantic-213/bin/python -m pytest tests/common/test_brokerage.py tests/common/test_request_serialization.py`
- `PYTHONPATH=src:tests /tmp/tradebot-pydantic-213/bin/python -m pytest`

Linear: FIA-132
