### PR TITLE
FIA-139: Define order and quote service ports

### DIFF
--- a/docs/service-ports.md
+++ b/docs/service-ports.md
@@ -1,0 +1,32 @@
+# TradeBot Service Ports
+
+This project uses "port" in two related but separate ways:
+
+- A service port is an internal dependency contract, following Ports and Adapters / Hexagonal Architecture.
+- A TCP port is the network port used when a service is deployed as a process.
+
+## Service dependency ports
+
+Managed order execution should depend on small service contracts instead of concrete in-process services. The current ports are:
+
+- `OrderServicePort`: the order operations required by managed execution.
+- `QuoteServicePort`: the quote lookup operation required by price-adjustment tactics.
+
+Concrete services such as ETrade order and quote services can satisfy these ports directly. Future local adapters and HTTP adapters should implement the same ports so managed execution can run in either mode:
+
+- Local mode: dependencies are ordinary in-process objects.
+- HTTP mode: dependencies are clients that call deployed service processes.
+
+The composition root should choose local or HTTP adapters at startup. Domain and orchestration logic should not branch on deployment mode.
+
+## TCP port convention
+
+Use the `80xx` range for public FastAPI service processes:
+
+- `8000`: reserved for a future gateway/API facade.
+- `8080`: orders service.
+- `8081`: quotes/accounts/portfolio service.
+- `8082`: managed order execution service.
+- `8083`: reserved for a future Trident service.
+
+Prefer stable port assignments over environment-specific reshuffling. Deployment environments can still remap external ports through Docker, Kubernetes Services, or ingress.

--- a/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
+++ b/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
@@ -45,25 +45,24 @@ from fianchetto_tradebot.common_models.order.order_price_type import OrderPriceT
 from fianchetto_tradebot.common_models.order.order_status import OrderStatus
 from fianchetto_tradebot.server.common.api.http_status_code import HttpStatusCode
 from fianchetto_tradebot.server.common.api.orders.etrade.etrade_order_service import ETradeOrderService
-from fianchetto_tradebot.server.common.api.orders.order_service import OrderService
 from fianchetto_tradebot.server.common.api.orders.order_util import OrderUtil
 from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import ETradeConnector
+from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
 from fianchetto_tradebot.server.common.service.service_key import ServiceKey
 from fianchetto_tradebot.server.common.threading.persistent_thread_pool import PersistentThreadPool
 from fianchetto_tradebot.server.orders.managed_order_execution import ManagedExecution, ManagedExecutionCreationParams, \
     ManagedExecutionCreationType
 from fianchetto_tradebot.server.orders.tactics.execution_tactic import ExecutionTactic
 from fianchetto_tradebot.server.quotes.etrade.etrade_quotes_service import ETradeQuotesService
-from fianchetto_tradebot.server.quotes.quotes_service import QuotesService
 
 class ManagedExecutionWorker:
-    def __init__(self, moex: ManagedExecution, moex_id: str, quotes_services: dict[Brokerage, QuotesService], orders_services: dict[Brokerage, OrderService]):
+    def __init__(self, moex: ManagedExecution, moex_id: str, quotes_services: dict[Brokerage, QuoteServicePort], orders_services: dict[Brokerage, OrderServicePort]):
         # This object gets modified in this process
         self.moex: ManagedExecution = moex
         self.moex_id: str = moex_id
         self.tactic: ExecutionTactic = moex.tactic
-        self.quotes_services: dict[Brokerage, QuotesService] = quotes_services
-        self.orders_services: dict[Brokerage, OrderService] = orders_services
+        self.quotes_services: dict[Brokerage, QuoteServicePort] = quotes_services
+        self.orders_services: dict[Brokerage, OrderServicePort] = orders_services
         self.continue_processing = True
 
     def stop(self):
@@ -159,9 +158,9 @@ class ManagedExecutionWorker:
         return ''.join(choice(characters) for _ in range(length))
 
 class MoexService:
-    def __init__(self, quotes_services: dict[Brokerage, QuotesService], orders_services: dict[Brokerage, OrderService]):
-        self.quotes_services: dict[Brokerage, QuotesService] = quotes_services
-        self.orders_services: dict[Brokerage, OrderService] = orders_services
+    def __init__(self, quotes_services: dict[Brokerage, QuoteServicePort], orders_services: dict[Brokerage, OrderServicePort]):
+        self.quotes_services: dict[Brokerage, QuoteServicePort] = quotes_services
+        self.orders_services: dict[Brokerage, OrderServicePort] = orders_services
 
         # todo - figure out a way to keep this running until it's explicitly closed
         self.thread_pool_executor = PersistentThreadPool(max_workers=10)
@@ -256,7 +255,7 @@ class MoexService:
 
             # cancel the order
             managed_execution : ManagedExecution = managed_execution
-            order_service: OrderService = self.orders_services[managed_execution.brokerage]
+            order_service: OrderServicePort = self.orders_services[managed_execution.brokerage]
             if managed_execution.current_brokerage_order_id:
                 cancel_order_request: CancelOrderRequest = CancelOrderRequest(account_id=managed_execution.account_id, order_id=managed_execution.current_brokerage_order_id)
                 cancel_order_response: CancelOrderResponse = order_service.cancel_order(cancel_order_request)
@@ -273,8 +272,8 @@ class MoexService:
         return self.current_id
 
 def create_moex_with_new_order_list_and_cancel(existing_order_id: str = None):
-    quotes_services = dict[Brokerage, QuotesService]()
-    orders_services = dict[Brokerage, OrderService]()
+    quotes_services = dict[Brokerage, QuoteServicePort]()
+    orders_services = dict[Brokerage, OrderServicePort]()
 
     connector: ETradeConnector = ETradeConnector()
     quotes_services[Brokerage.ETRADE] = ETradeQuotesService(connector)
@@ -334,4 +333,3 @@ if __name__ == "__main__":
     print(f"Testing with new order: {existing_order_id}")
     create_moex_with_new_order_list_and_cancel(str(existing_order_id))
     print("End test with new order")
-

--- a/src/fianchetto_tradebot/server/common/service/ports/__init__.py
+++ b/src/fianchetto_tradebot/server/common/service/ports/__init__.py
@@ -1,0 +1,4 @@
+from fianchetto_tradebot.server.common.service.ports.order_service_port import OrderServicePort
+from fianchetto_tradebot.server.common.service.ports.quote_service_port import QuoteServicePort
+
+__all__ = ["OrderServicePort", "QuoteServicePort"]

--- a/src/fianchetto_tradebot/server/common/service/ports/order_service_port.py
+++ b/src/fianchetto_tradebot/server/common/service/ports/order_service_port.py
@@ -1,0 +1,26 @@
+from typing import Protocol, runtime_checkable
+
+from fianchetto_tradebot.common_models.api.orders.cancel_order_request import CancelOrderRequest
+from fianchetto_tradebot.common_models.api.orders.cancel_order_response import CancelOrderResponse
+from fianchetto_tradebot.common_models.api.orders.get_order_request import GetOrderRequest
+from fianchetto_tradebot.common_models.api.orders.get_order_response import GetOrderResponse
+from fianchetto_tradebot.common_models.api.orders.place_order_response import PlaceOrderResponse
+from fianchetto_tradebot.common_models.api.orders.preview_modify_order_request import PreviewModifyOrderRequest
+from fianchetto_tradebot.common_models.api.orders.preview_order_request import PreviewOrderRequest
+
+
+@runtime_checkable
+class OrderServicePort(Protocol):
+    """Order dependency surface required by managed execution services."""
+
+    def get_order(self, get_order_request: GetOrderRequest) -> GetOrderResponse:
+        ...
+
+    def cancel_order(self, cancel_order_request: CancelOrderRequest) -> CancelOrderResponse:
+        ...
+
+    def preview_and_place_order(self, preview_order_request: PreviewOrderRequest) -> PlaceOrderResponse:
+        ...
+
+    def modify_order(self, preview_modify_order_request: PreviewModifyOrderRequest) -> PlaceOrderResponse:
+        ...

--- a/src/fianchetto_tradebot/server/common/service/ports/quote_service_port.py
+++ b/src/fianchetto_tradebot/server/common/service/ports/quote_service_port.py
@@ -1,0 +1,12 @@
+from typing import Protocol, runtime_checkable
+
+from fianchetto_tradebot.common_models.api.quotes.get_tradable_request import GetTradableRequest
+from fianchetto_tradebot.common_models.api.quotes.get_tradable_response import GetTradableResponse
+
+
+@runtime_checkable
+class QuoteServicePort(Protocol):
+    """Quote dependency surface required by managed execution services."""
+
+    def get_tradable_quote(self, request: GetTradableRequest) -> GetTradableResponse:
+        ...

--- a/src/fianchetto_tradebot/server/moex/serving/moex_rest_service.py
+++ b/src/fianchetto_tradebot/server/moex/serving/moex_rest_service.py
@@ -20,13 +20,12 @@ from fianchetto_tradebot.common_models.managed_executions.list_managed_execution
     ListManagedExecutionsResponse
 from fianchetto_tradebot.server.common.api.moex.moex_service import MoexService
 from fianchetto_tradebot.server.common.api.orders.etrade.etrade_order_service import ETradeOrderService
-from fianchetto_tradebot.server.common.api.orders.order_service import OrderService
 from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import ETradeConnector
 from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
 from fianchetto_tradebot.server.common.service.rest_service import RestService, ETRADE_ONLY_BROKERAGE_CONFIG
 from fianchetto_tradebot.server.common.service.service_key import ServiceKey
 from fianchetto_tradebot.server.quotes.etrade.etrade_quotes_service import ETradeQuotesService
-from fianchetto_tradebot.server.quotes.quotes_service import QuotesService
 
 JAN_1_2024 = datetime(2024,1,1).date()
 DEFAULT_START_DATE = JAN_1_2024
@@ -63,8 +62,8 @@ class MoexRestService(RestService):
 
 
     def _setup_brokerage_services(self):
-        self.order_services: dict[Brokerage, OrderService] = dict()
-        self.quotes_services: dict[Brokerage, QuotesService] = dict()
+        self.order_services: dict[Brokerage, OrderServicePort] = dict()
+        self.quotes_services: dict[Brokerage, QuoteServicePort] = dict()
 
         # E*Trade
         etrade_key: Brokerage = Brokerage.ETRADE

--- a/src/fianchetto_tradebot/server/orders/tactics/incremental_price_delta_execution_tactic.py
+++ b/src/fianchetto_tradebot/server/orders/tactics/incremental_price_delta_execution_tactic.py
@@ -7,9 +7,9 @@ from fianchetto_tradebot.common_models.order.order import Order
 from fianchetto_tradebot.common_models.order.order_price import OrderPrice
 from fianchetto_tradebot.common_models.order.order_price_type import OrderPriceType
 from fianchetto_tradebot.common_models.order.order_type import OrderType
+from fianchetto_tradebot.server.common.service.ports import QuoteServicePort
 from fianchetto_tradebot.server.orders.tactics.execution_tactic import ExecutionTactic, register_tactic
 from fianchetto_tradebot.server.orders.trade_execution_util import TradeExecutionUtil
-from fianchetto_tradebot.server.quotes.quotes_service import QuotesService
 
 GAP_REDUCTION_RATIO = 1/3
 DEFAULT_WAIT_SEC = 5
@@ -18,7 +18,7 @@ VERY_CLOSE_TO_MARKET_PRICE_WAIT = 30
 @register_tactic
 class IncrementalPriceDeltaExecutionTactic(ExecutionTactic):
     @staticmethod
-    def new_price(order: Order, quotes_service: QuotesService=None)->(OrderPrice, int):
+    def new_price(order: Order, quotes_service: QuoteServicePort=None)->(OrderPrice, int):
 
         current_order_price: float = order.order_price.price.to_float()
         if order.get_order_type() == OrderType.EQ:

--- a/src/fianchetto_tradebot/server/orders/trade_execution_util.py
+++ b/src/fianchetto_tradebot/server/orders/trade_execution_util.py
@@ -6,7 +6,7 @@ from fianchetto_tradebot.common_models.finance.price import Price
 from fianchetto_tradebot.common_models.order.action import Action
 from fianchetto_tradebot.common_models.order.order import Order
 from fianchetto_tradebot.common_models.api.quotes.get_tradable_response import GetTradableResponse
-from fianchetto_tradebot.server.quotes.quotes_service import QuotesService
+from fianchetto_tradebot.server.common.service.ports import QuoteServicePort
 
 ADJUSTED_NO_BIDS_WIDE_SPREAD_ASK = .03
 
@@ -16,7 +16,7 @@ class TradeExecutionUtil:
 
     # This is a bit unintuitive for Equity orders, but this returns affect on cash to actuate the position.
     @staticmethod
-    def get_cost_or_proceeds_to_establish_position(order: Order, quote_service: QuotesService, adjust_excessive_spreads=True) -> Price:
+    def get_cost_or_proceeds_to_establish_position(order: Order, quote_service: QuoteServicePort, adjust_excessive_spreads=True) -> Price:
         mark_to_market_price: float = 0
         best_price: float = 0
         worst_price: float = 0

--- a/tests/common/service/test_service_ports.py
+++ b/tests/common/service/test_service_ports.py
@@ -1,0 +1,36 @@
+from fianchetto_tradebot.server.common.api.orders.etrade.etrade_order_service import ETradeOrderService
+from fianchetto_tradebot.server.common.api.orders.order_service import OrderService
+from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
+from fianchetto_tradebot.server.quotes.etrade.etrade_quotes_service import ETradeQuotesService
+from fianchetto_tradebot.server.quotes.quotes_service import QuotesService
+
+
+class FakeOrderService:
+    def get_order(self, get_order_request):
+        pass
+
+    def cancel_order(self, cancel_order_request):
+        pass
+
+    def preview_and_place_order(self, preview_order_request):
+        pass
+
+    def modify_order(self, preview_modify_order_request):
+        pass
+
+
+class FakeQuoteService:
+    def get_tradable_quote(self, request):
+        pass
+
+
+def test_order_port_is_runtime_structural_contract():
+    assert isinstance(FakeOrderService(), OrderServicePort)
+    assert isinstance(object.__new__(OrderService), OrderServicePort)
+    assert isinstance(object.__new__(ETradeOrderService), OrderServicePort)
+
+
+def test_quote_port_is_runtime_structural_contract():
+    assert isinstance(FakeQuoteService(), QuoteServicePort)
+    assert isinstance(object.__new__(QuotesService), QuoteServicePort)
+    assert isinstance(object.__new__(ETradeQuotesService), QuoteServicePort)


### PR DESCRIPTION
## Summary

- Add narrow `OrderServicePort` and `QuoteServicePort` protocols for managed execution dependencies.
- Re-annotate MOEX service wiring and price-adjustment helpers to depend on those ports instead of concrete in-process services.
- Document the service-port vs TCP-port convention, including the `80xx` service range.
- Add a focused contract test covering the structural service ports.

## Validation

- `/tmp/tradebot-fia139-venv/bin/python -m pytest tests/common/service/test_service_ports.py tests/moex/worker/eviction/test_moex_eviction.py tests/oex/test_incremental_price_tactic.py` - 10 passed
- `/tmp/tradebot-fia139-venv/bin/python -m pytest` - 149 passed, 4 skipped

Note: local validation used a throwaway Python 3.12 venv with `--ignore-requires-python` because this machine does not have Python 3.14 installed. GitHub Actions is configured to run the canonical Python 3.14 stack.
