### PR TITLE
FIA-140: Add local service adapters

### DIFF
--- a/docs/service-ports.md
+++ b/docs/service-ports.md
@@ -19,6 +19,14 @@ Concrete services such as ETrade order and quote services can satisfy these port
 
 The composition root should choose local or HTTP adapters at startup. Domain and orchestration logic should not branch on deployment mode.
 
+Local mode uses explicit adapter wrappers:
+
+- `LocalOrderServiceAdapter`
+- `LocalQuoteServiceAdapter`
+- `build_local_service_adapters`
+
+These adapters preserve ordinary in-process debugging while giving deployed HTTP clients a clear interface to implement later.
+
 ## TCP port convention
 
 Use the `80xx` range for public FastAPI service processes:

--- a/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
+++ b/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
@@ -44,16 +44,15 @@ from fianchetto_tradebot.common_models.order.order_price import OrderPrice
 from fianchetto_tradebot.common_models.order.order_price_type import OrderPriceType
 from fianchetto_tradebot.common_models.order.order_status import OrderStatus
 from fianchetto_tradebot.server.common.api.http_status_code import HttpStatusCode
-from fianchetto_tradebot.server.common.api.orders.etrade.etrade_order_service import ETradeOrderService
 from fianchetto_tradebot.server.common.api.orders.order_util import OrderUtil
 from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import ETradeConnector
+from fianchetto_tradebot.server.common.service.adapters import build_local_service_adapters
 from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
 from fianchetto_tradebot.server.common.service.service_key import ServiceKey
 from fianchetto_tradebot.server.common.threading.persistent_thread_pool import PersistentThreadPool
 from fianchetto_tradebot.server.orders.managed_order_execution import ManagedExecution, ManagedExecutionCreationParams, \
     ManagedExecutionCreationType
 from fianchetto_tradebot.server.orders.tactics.execution_tactic import ExecutionTactic
-from fianchetto_tradebot.server.quotes.etrade.etrade_quotes_service import ETradeQuotesService
 
 class ManagedExecutionWorker:
     def __init__(self, moex: ManagedExecution, moex_id: str, quotes_services: dict[Brokerage, QuoteServicePort], orders_services: dict[Brokerage, OrderServicePort]):
@@ -272,14 +271,10 @@ class MoexService:
         return self.current_id
 
 def create_moex_with_new_order_list_and_cancel(existing_order_id: str = None):
-    quotes_services = dict[Brokerage, QuoteServicePort]()
-    orders_services = dict[Brokerage, OrderServicePort]()
-
     connector: ETradeConnector = ETradeConnector()
-    quotes_services[Brokerage.ETRADE] = ETradeQuotesService(connector)
-    orders_services[Brokerage.ETRADE] = ETradeOrderService(connector)
+    local_services = build_local_service_adapters({Brokerage.ETRADE: connector})
 
-    moex_service: MoexService = MoexService(quotes_services, orders_services)
+    moex_service: MoexService = MoexService(local_services.quote_services, local_services.order_services)
     app_thread = threading.Thread(target=moex_service.run)
     app_thread.start()
 

--- a/src/fianchetto_tradebot/server/common/service/adapters/__init__.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/__init__.py
@@ -1,0 +1,13 @@
+from fianchetto_tradebot.server.common.service.adapters.local_brokerage_service_adapters import (
+    LocalServiceAdapters,
+    build_local_service_adapters,
+)
+from fianchetto_tradebot.server.common.service.adapters.local_order_service_adapter import LocalOrderServiceAdapter
+from fianchetto_tradebot.server.common.service.adapters.local_quote_service_adapter import LocalQuoteServiceAdapter
+
+__all__ = [
+    "LocalOrderServiceAdapter",
+    "LocalQuoteServiceAdapter",
+    "LocalServiceAdapters",
+    "build_local_service_adapters",
+]

--- a/src/fianchetto_tradebot/server/common/service/adapters/local_brokerage_service_adapters.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/local_brokerage_service_adapters.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import cast
+
+from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.server.common.api.orders.etrade.etrade_order_service import ETradeOrderService
+from fianchetto_tradebot.server.common.brokerage.connector import Connector
+from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import ETradeConnector
+from fianchetto_tradebot.server.common.service.adapters.local_order_service_adapter import LocalOrderServiceAdapter
+from fianchetto_tradebot.server.common.service.adapters.local_quote_service_adapter import LocalQuoteServiceAdapter
+from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
+from fianchetto_tradebot.server.quotes.etrade.etrade_quotes_service import ETradeQuotesService
+
+
+@dataclass(frozen=True)
+class LocalServiceAdapters:
+    order_services: dict[Brokerage, OrderServicePort]
+    quote_services: dict[Brokerage, QuoteServicePort]
+
+
+def build_local_service_adapters(connectors: dict[Brokerage, Connector]) -> LocalServiceAdapters:
+    order_services: dict[Brokerage, OrderServicePort] = dict()
+    quote_services: dict[Brokerage, QuoteServicePort] = dict()
+
+    for brokerage, connector in connectors.items():
+        if brokerage == Brokerage.ETRADE:
+            etrade_connector = cast(ETradeConnector, connector)
+            order_services[brokerage] = LocalOrderServiceAdapter(ETradeOrderService(etrade_connector))
+            quote_services[brokerage] = LocalQuoteServiceAdapter(ETradeQuotesService(etrade_connector))
+        else:
+            raise NotImplementedError(f"Local service adapters are not implemented for {brokerage}")
+
+    return LocalServiceAdapters(order_services=order_services, quote_services=quote_services)

--- a/src/fianchetto_tradebot/server/common/service/adapters/local_order_service_adapter.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/local_order_service_adapter.py
@@ -1,0 +1,25 @@
+from fianchetto_tradebot.common_models.api.orders.cancel_order_request import CancelOrderRequest
+from fianchetto_tradebot.common_models.api.orders.cancel_order_response import CancelOrderResponse
+from fianchetto_tradebot.common_models.api.orders.get_order_request import GetOrderRequest
+from fianchetto_tradebot.common_models.api.orders.get_order_response import GetOrderResponse
+from fianchetto_tradebot.common_models.api.orders.place_order_response import PlaceOrderResponse
+from fianchetto_tradebot.common_models.api.orders.preview_modify_order_request import PreviewModifyOrderRequest
+from fianchetto_tradebot.common_models.api.orders.preview_order_request import PreviewOrderRequest
+from fianchetto_tradebot.server.common.service.ports import OrderServicePort
+
+
+class LocalOrderServiceAdapter(OrderServicePort):
+    def __init__(self, service: OrderServicePort):
+        self.service = service
+
+    def get_order(self, get_order_request: GetOrderRequest) -> GetOrderResponse:
+        return self.service.get_order(get_order_request)
+
+    def cancel_order(self, cancel_order_request: CancelOrderRequest) -> CancelOrderResponse:
+        return self.service.cancel_order(cancel_order_request)
+
+    def preview_and_place_order(self, preview_order_request: PreviewOrderRequest) -> PlaceOrderResponse:
+        return self.service.preview_and_place_order(preview_order_request)
+
+    def modify_order(self, preview_modify_order_request: PreviewModifyOrderRequest) -> PlaceOrderResponse:
+        return self.service.modify_order(preview_modify_order_request)

--- a/src/fianchetto_tradebot/server/common/service/adapters/local_quote_service_adapter.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/local_quote_service_adapter.py
@@ -1,0 +1,11 @@
+from fianchetto_tradebot.common_models.api.quotes.get_tradable_request import GetTradableRequest
+from fianchetto_tradebot.common_models.api.quotes.get_tradable_response import GetTradableResponse
+from fianchetto_tradebot.server.common.service.ports import QuoteServicePort
+
+
+class LocalQuoteServiceAdapter(QuoteServicePort):
+    def __init__(self, service: QuoteServicePort):
+        self.service = service
+
+    def get_tradable_quote(self, request: GetTradableRequest) -> GetTradableResponse:
+        return self.service.get_tradable_quote(request)

--- a/src/fianchetto_tradebot/server/moex/serving/moex_rest_service.py
+++ b/src/fianchetto_tradebot/server/moex/serving/moex_rest_service.py
@@ -19,13 +19,11 @@ from fianchetto_tradebot.common_models.managed_executions.list_managed_execution
 from fianchetto_tradebot.common_models.managed_executions.list_managed_executions_response import \
     ListManagedExecutionsResponse
 from fianchetto_tradebot.server.common.api.moex.moex_service import MoexService
-from fianchetto_tradebot.server.common.api.orders.etrade.etrade_order_service import ETradeOrderService
-from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import ETradeConnector
 from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.server.common.service.adapters import build_local_service_adapters
 from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
 from fianchetto_tradebot.server.common.service.rest_service import RestService, ETRADE_ONLY_BROKERAGE_CONFIG
 from fianchetto_tradebot.server.common.service.service_key import ServiceKey
-from fianchetto_tradebot.server.quotes.etrade.etrade_quotes_service import ETradeQuotesService
 
 JAN_1_2024 = datetime(2024,1,1).date()
 DEFAULT_START_DATE = JAN_1_2024
@@ -62,19 +60,9 @@ class MoexRestService(RestService):
 
 
     def _setup_brokerage_services(self):
-        self.order_services: dict[Brokerage, OrderServicePort] = dict()
-        self.quotes_services: dict[Brokerage, QuoteServicePort] = dict()
-
-        # E*Trade
-        etrade_key: Brokerage = Brokerage.ETRADE
-        etrade_connector: ETradeConnector = self.connectors[Brokerage.ETRADE]
-        etrade_order_service = ETradeOrderService(etrade_connector)
-        etrade_quotes_service = ETradeQuotesService(etrade_connector)
-
-        self.order_services[etrade_key] = etrade_order_service
-        self.quotes_services[etrade_key] = etrade_quotes_service
-
-        # TODO: Add for IBKR and Schwab
+        local_services = build_local_service_adapters(self.connectors)
+        self.order_services: dict[Brokerage, OrderServicePort] = local_services.order_services
+        self.quotes_services: dict[Brokerage, QuoteServicePort] = local_services.quote_services
         self.moex_service = MoexService(self.quotes_services, self.order_services)
 
     def list_managed_executions(self, brokerage: str, account_id: str):

--- a/tests/common/service/test_local_service_adapters.py
+++ b/tests/common/service/test_local_service_adapters.py
@@ -1,0 +1,77 @@
+from unittest.mock import Mock
+
+import pytest
+
+from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.server.common.brokerage.connector import Connector
+from fianchetto_tradebot.server.common.service.adapters import (
+    LocalOrderServiceAdapter,
+    LocalQuoteServiceAdapter,
+    build_local_service_adapters,
+)
+from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
+
+
+class FakeConnector(Connector):
+    brokerage = "ETRADE"
+
+    def load_connection(self):
+        return Mock(), Mock(), "https://local.test"
+
+
+def test_local_order_adapter_delegates_to_wrapped_service():
+    service = Mock()
+    adapter = LocalOrderServiceAdapter(service)
+
+    get_order_request = object()
+    get_order_response = object()
+    service.get_order.return_value = get_order_response
+    assert adapter.get_order(get_order_request) is get_order_response
+    service.get_order.assert_called_once_with(get_order_request)
+
+    cancel_order_request = object()
+    cancel_order_response = object()
+    service.cancel_order.return_value = cancel_order_response
+    assert adapter.cancel_order(cancel_order_request) is cancel_order_response
+    service.cancel_order.assert_called_once_with(cancel_order_request)
+
+    preview_order_request = object()
+    place_order_response = object()
+    service.preview_and_place_order.return_value = place_order_response
+    assert adapter.preview_and_place_order(preview_order_request) is place_order_response
+    service.preview_and_place_order.assert_called_once_with(preview_order_request)
+
+    preview_modify_order_request = object()
+    modify_order_response = object()
+    service.modify_order.return_value = modify_order_response
+    assert adapter.modify_order(preview_modify_order_request) is modify_order_response
+    service.modify_order.assert_called_once_with(preview_modify_order_request)
+
+
+def test_local_quote_adapter_delegates_to_wrapped_service():
+    service = Mock()
+    adapter = LocalQuoteServiceAdapter(service)
+
+    request = object()
+    response = object()
+    service.get_tradable_quote.return_value = response
+
+    assert adapter.get_tradable_quote(request) is response
+    service.get_tradable_quote.assert_called_once_with(request)
+
+
+def test_build_local_service_adapters_creates_etrade_port_adapters():
+    local_services = build_local_service_adapters({Brokerage.ETRADE: FakeConnector()})
+
+    order_service = local_services.order_services[Brokerage.ETRADE]
+    quote_service = local_services.quote_services[Brokerage.ETRADE]
+
+    assert isinstance(order_service, LocalOrderServiceAdapter)
+    assert isinstance(order_service, OrderServicePort)
+    assert isinstance(quote_service, LocalQuoteServiceAdapter)
+    assert isinstance(quote_service, QuoteServicePort)
+
+
+def test_build_local_service_adapters_rejects_unsupported_brokerage():
+    with pytest.raises(NotImplementedError, match="Local service adapters are not implemented"):
+        build_local_service_adapters({Brokerage.IBKR: FakeConnector()})


### PR DESCRIPTION
## Summary

- Add explicit local in-process adapters for the order and quote service ports.
- Add a local service-adapter composition helper that builds ETrade-backed port adapters from existing connectors.
- Refactor MOEX REST setup and the manual MOEX runner to use the centralized local adapter wiring.
- Document the local adapter convention alongside the service-port guidance.
- Add focused adapter delegation and factory tests.

## Validation

- `/tmp/tradebot-fia139-venv/bin/python -m pytest tests/common/service/test_service_ports.py tests/common/service/test_local_service_adapters.py tests/moex/worker/eviction/test_moex_eviction.py tests/oex/test_incremental_price_tactic.py` - 14 passed
- `/tmp/tradebot-fia139-venv/bin/python -m pytest` - 153 passed, 4 skipped

Note: local validation used the existing throwaway Python 3.12 venv with `--ignore-requires-python` because this machine does not have Python 3.14 installed. GitHub Actions will run the canonical Python 3.14 workflow.
