### PR TITLE
FIA-141: Add HTTP service adapters

### DIFF
--- a/docs/service-ports.md
+++ b/docs/service-ports.md
@@ -27,6 +27,23 @@ Local mode uses explicit adapter wrappers:
 
 These adapters preserve ordinary in-process debugging while giving deployed HTTP clients a clear interface to implement later.
 
+HTTP mode uses adapter wrappers that receive generic base URLs:
+
+- `HttpOrderServiceAdapter`
+- `HttpQuoteServiceAdapter`
+- `build_http_service_adapters`
+- `orders_base_url`
+- `quotes_base_url`
+
+The environment variable names are deployment-neutral:
+
+- `TRADEBOT_ORDERS_SERVICE_URL`
+- `TRADEBOT_QUOTES_SERVICE_URL`
+
+Code defaults point at local development ports. Docker Compose and Kubernetes should override those values with the right service DNS names for that environment.
+
+HTTP adapters should construct URLs using the route path values required by the target service. FastAPI handlers do not need to accept every path value when the handler only needs the parsed Pydantic request body.
+
 ## TCP port convention
 
 Use the `80xx` range for public FastAPI service processes:

--- a/src/fianchetto_tradebot/server/common/service/adapters/__init__.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/__init__.py
@@ -1,13 +1,39 @@
+from fianchetto_tradebot.server.common.service.adapters.http_brokerage_service_adapters import (
+    build_http_service_adapters,
+)
+from fianchetto_tradebot.server.common.service.adapters.http_order_service_adapter import HttpOrderServiceAdapter
+from fianchetto_tradebot.server.common.service.adapters.http_quote_service_adapter import HttpQuoteServiceAdapter
+from fianchetto_tradebot.server.common.service.adapters.http_service_adapter_config import (
+    DEFAULT_ORDERS_SERVICE_URL,
+    DEFAULT_QUOTES_SERVICE_URL,
+    ORDERS_SERVICE_URL_ENV_VAR,
+    QUOTES_SERVICE_URL_ENV_VAR,
+    HttpServiceAdapterConfig,
+    load_http_service_adapter_config,
+)
+from fianchetto_tradebot.server.common.service.adapters.http_service_adapter_error import HttpServiceAdapterError
 from fianchetto_tradebot.server.common.service.adapters.local_brokerage_service_adapters import (
     LocalServiceAdapters,
     build_local_service_adapters,
 )
 from fianchetto_tradebot.server.common.service.adapters.local_order_service_adapter import LocalOrderServiceAdapter
 from fianchetto_tradebot.server.common.service.adapters.local_quote_service_adapter import LocalQuoteServiceAdapter
+from fianchetto_tradebot.server.common.service.adapters.service_adapters import ServiceAdapters
 
 __all__ = [
+    "DEFAULT_ORDERS_SERVICE_URL",
+    "DEFAULT_QUOTES_SERVICE_URL",
+    "HttpOrderServiceAdapter",
+    "HttpQuoteServiceAdapter",
+    "HttpServiceAdapterConfig",
+    "HttpServiceAdapterError",
     "LocalOrderServiceAdapter",
     "LocalQuoteServiceAdapter",
     "LocalServiceAdapters",
+    "ORDERS_SERVICE_URL_ENV_VAR",
+    "QUOTES_SERVICE_URL_ENV_VAR",
+    "ServiceAdapters",
+    "build_http_service_adapters",
     "build_local_service_adapters",
+    "load_http_service_adapter_config",
 ]

--- a/src/fianchetto_tradebot/server/common/service/adapters/http_brokerage_service_adapters.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/http_brokerage_service_adapters.py
@@ -1,0 +1,38 @@
+from collections.abc import Iterable
+
+import httpx
+
+from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.server.common.service.adapters.http_order_service_adapter import HttpOrderServiceAdapter
+from fianchetto_tradebot.server.common.service.adapters.http_quote_service_adapter import HttpQuoteServiceAdapter
+from fianchetto_tradebot.server.common.service.adapters.http_service_adapter_config import (
+    HttpServiceAdapterConfig,
+    load_http_service_adapter_config,
+)
+from fianchetto_tradebot.server.common.service.adapters.service_adapters import ServiceAdapters
+from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
+
+
+def build_http_service_adapters(
+        brokerages: Iterable[Brokerage],
+        config: HttpServiceAdapterConfig | None = None,
+        orders_client: httpx.Client | None = None,
+        quotes_client: httpx.Client | None = None,
+) -> ServiceAdapters:
+    config = config or load_http_service_adapter_config()
+    order_services: dict[Brokerage, OrderServicePort] = dict()
+    quote_services: dict[Brokerage, QuoteServicePort] = dict()
+
+    for brokerage in brokerages:
+        order_services[brokerage] = HttpOrderServiceAdapter(
+            brokerage=brokerage,
+            orders_base_url=config.orders_base_url,
+            client=orders_client,
+        )
+        quote_services[brokerage] = HttpQuoteServiceAdapter(
+            brokerage=brokerage,
+            quotes_base_url=config.quotes_base_url,
+            client=quotes_client,
+        )
+
+    return ServiceAdapters(order_services=order_services, quote_services=quote_services)

--- a/src/fianchetto_tradebot/server/common/service/adapters/http_order_service_adapter.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/http_order_service_adapter.py
@@ -1,0 +1,51 @@
+import httpx
+
+from fianchetto_tradebot.common_models.api.orders.cancel_order_request import CancelOrderRequest
+from fianchetto_tradebot.common_models.api.orders.cancel_order_response import CancelOrderResponse
+from fianchetto_tradebot.common_models.api.orders.get_order_request import GetOrderRequest
+from fianchetto_tradebot.common_models.api.orders.get_order_response import GetOrderResponse
+from fianchetto_tradebot.common_models.api.orders.place_order_response import PlaceOrderResponse
+from fianchetto_tradebot.common_models.api.orders.preview_modify_order_request import PreviewModifyOrderRequest
+from fianchetto_tradebot.common_models.api.orders.preview_order_request import PreviewOrderRequest
+from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.server.common.service.adapters.http_service_adapter import HttpServiceAdapter
+from fianchetto_tradebot.server.common.service.ports import OrderServicePort
+
+
+class HttpOrderServiceAdapter(HttpServiceAdapter, OrderServicePort):
+    def __init__(self, brokerage: Brokerage, orders_base_url: str, client: httpx.Client | None = None):
+        super().__init__(orders_base_url, client)
+        self.brokerage = brokerage
+
+    def get_order(self, get_order_request: GetOrderRequest) -> GetOrderResponse:
+        response = self._request(
+            "GET",
+            f"/api/v1/{self.brokerage.value}/accounts/{get_order_request.account_id}/orders/{get_order_request.order_id}",
+        )
+        return GetOrderResponse.model_validate(response.json())
+
+    def cancel_order(self, cancel_order_request: CancelOrderRequest) -> CancelOrderResponse:
+        response = self._request(
+            "DELETE",
+            f"/api/v1/{self.brokerage.value}/accounts/{cancel_order_request.account_id}/orders/{cancel_order_request.order_id}",
+        )
+        return CancelOrderResponse.model_validate(response.json())
+
+    def preview_and_place_order(self, preview_order_request: PreviewOrderRequest) -> PlaceOrderResponse:
+        account_id = preview_order_request.order_metadata.account_id
+        response = self._request(
+            "POST",
+            f"/api/v1/{self.brokerage.value}/accounts/{account_id}/orders/preview_and_place",
+            json=self._json_payload(preview_order_request),
+        )
+        return PlaceOrderResponse.model_validate(response.json())
+
+    def modify_order(self, preview_modify_order_request: PreviewModifyOrderRequest) -> PlaceOrderResponse:
+        account_id = preview_modify_order_request.order_metadata.account_id
+        order_id = preview_modify_order_request.order_id_to_modify
+        response = self._request(
+            "PUT",
+            f"/api/v1/{self.brokerage.value}/accounts/{account_id}/orders/{order_id}",
+            json=self._json_payload(preview_modify_order_request),
+        )
+        return PlaceOrderResponse.model_validate(response.json())

--- a/src/fianchetto_tradebot/server/common/service/adapters/http_quote_service_adapter.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/http_quote_service_adapter.py
@@ -1,0 +1,41 @@
+from urllib.parse import quote
+
+import httpx
+
+from fianchetto_tradebot.common_models.api.quotes.get_tradable_request import GetTradableRequest
+from fianchetto_tradebot.common_models.api.quotes.get_tradable_response import GetTradableResponse
+from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.common_models.finance.equity import Equity
+from fianchetto_tradebot.common_models.finance.option import Option
+from fianchetto_tradebot.common_models.finance.tradable import Tradable
+from fianchetto_tradebot.server.common.service.adapters.http_service_adapter import HttpServiceAdapter
+from fianchetto_tradebot.server.common.service.ports import QuoteServicePort
+
+
+class HttpQuoteServiceAdapter(HttpServiceAdapter, QuoteServicePort):
+    def __init__(self, brokerage: Brokerage, quotes_base_url: str, client: httpx.Client | None = None):
+        super().__init__(quotes_base_url, client)
+        self.brokerage = brokerage
+
+    def get_tradable_quote(self, request: GetTradableRequest) -> GetTradableResponse:
+        symbol = self._tradable_symbol(request.tradable)
+        encoded_symbol = quote(symbol, safe="")
+        response = self._request(
+            "GET",
+            f"/api/v1/{self.brokerage.value}/quotes/tradable/{encoded_symbol}",
+        )
+        return GetTradableResponse.model_validate(response.json())
+
+    @staticmethod
+    def _tradable_symbol(tradable: Tradable) -> str:
+        if isinstance(tradable, Equity):
+            return tradable.ticker
+
+        if isinstance(tradable, Option):
+            expiry = tradable.expiry
+            return (
+                f"{tradable.equity.ticker}:{expiry.year}:{expiry.month}:{expiry.day}:"
+                f"{tradable.type.value}:{tradable.strike.to_float()}"
+            )
+
+        raise ValueError(f"Tradable type {type(tradable)} is not supported by HTTP quote adapter")

--- a/src/fianchetto_tradebot/server/common/service/adapters/http_service_adapter.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/http_service_adapter.py
@@ -1,0 +1,32 @@
+from typing import Any
+
+import httpx
+from pydantic import BaseModel
+
+from fianchetto_tradebot.server.common.service.adapters.http_service_adapter_error import HttpServiceAdapterError
+
+DEFAULT_HTTP_TIMEOUT_SECONDS = 10.0
+
+
+class HttpServiceAdapter:
+    def __init__(self, base_url: str, client: httpx.Client | None = None, timeout: float = DEFAULT_HTTP_TIMEOUT_SECONDS):
+        self.base_url = base_url.rstrip("/")
+        self.client = client or httpx.Client()
+        self.timeout = timeout
+
+    @staticmethod
+    def _json_payload(model: BaseModel) -> dict[str, Any]:
+        return model.model_dump(mode="json")
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}/{path.lstrip('/')}"
+
+    def _request(self, method: str, path: str, **kwargs) -> httpx.Response:
+        response = self.client.request(method, self._url(path), timeout=self.timeout, **kwargs)
+        if response.is_error:
+            raise HttpServiceAdapterError(
+                message=f"{method} {response.url} failed with HTTP {response.status_code}",
+                status_code=response.status_code,
+                response_text=response.text,
+            )
+        return response

--- a/src/fianchetto_tradebot/server/common/service/adapters/http_service_adapter_config.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/http_service_adapter_config.py
@@ -1,0 +1,21 @@
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+DEFAULT_ORDERS_SERVICE_URL = "http://localhost:8080"
+DEFAULT_QUOTES_SERVICE_URL = "http://localhost:8081"
+ORDERS_SERVICE_URL_ENV_VAR = "TRADEBOT_ORDERS_SERVICE_URL"
+QUOTES_SERVICE_URL_ENV_VAR = "TRADEBOT_QUOTES_SERVICE_URL"
+
+
+@dataclass(frozen=True)
+class HttpServiceAdapterConfig:
+    orders_base_url: str = DEFAULT_ORDERS_SERVICE_URL
+    quotes_base_url: str = DEFAULT_QUOTES_SERVICE_URL
+
+
+def load_http_service_adapter_config(env: Mapping[str, str] = os.environ) -> HttpServiceAdapterConfig:
+    return HttpServiceAdapterConfig(
+        orders_base_url=env.get(ORDERS_SERVICE_URL_ENV_VAR, DEFAULT_ORDERS_SERVICE_URL),
+        quotes_base_url=env.get(QUOTES_SERVICE_URL_ENV_VAR, DEFAULT_QUOTES_SERVICE_URL),
+    )

--- a/src/fianchetto_tradebot/server/common/service/adapters/http_service_adapter_error.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/http_service_adapter_error.py
@@ -1,0 +1,5 @@
+class HttpServiceAdapterError(Exception):
+    def __init__(self, message: str, status_code: int, response_text: str):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_text = response_text

--- a/src/fianchetto_tradebot/server/common/service/adapters/local_brokerage_service_adapters.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/local_brokerage_service_adapters.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import cast
 
 from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
@@ -7,17 +6,15 @@ from fianchetto_tradebot.server.common.brokerage.connector import Connector
 from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import ETradeConnector
 from fianchetto_tradebot.server.common.service.adapters.local_order_service_adapter import LocalOrderServiceAdapter
 from fianchetto_tradebot.server.common.service.adapters.local_quote_service_adapter import LocalQuoteServiceAdapter
+from fianchetto_tradebot.server.common.service.adapters.service_adapters import ServiceAdapters
 from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
 from fianchetto_tradebot.server.quotes.etrade.etrade_quotes_service import ETradeQuotesService
 
 
-@dataclass(frozen=True)
-class LocalServiceAdapters:
-    order_services: dict[Brokerage, OrderServicePort]
-    quote_services: dict[Brokerage, QuoteServicePort]
+LocalServiceAdapters = ServiceAdapters
 
 
-def build_local_service_adapters(connectors: dict[Brokerage, Connector]) -> LocalServiceAdapters:
+def build_local_service_adapters(connectors: dict[Brokerage, Connector]) -> ServiceAdapters:
     order_services: dict[Brokerage, OrderServicePort] = dict()
     quote_services: dict[Brokerage, QuoteServicePort] = dict()
 
@@ -29,4 +26,4 @@ def build_local_service_adapters(connectors: dict[Brokerage, Connector]) -> Loca
         else:
             raise NotImplementedError(f"Local service adapters are not implemented for {brokerage}")
 
-    return LocalServiceAdapters(order_services=order_services, quote_services=quote_services)
+    return ServiceAdapters(order_services=order_services, quote_services=quote_services)

--- a/src/fianchetto_tradebot/server/common/service/adapters/service_adapters.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/service_adapters.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
+
+
+@dataclass(frozen=True)
+class ServiceAdapters:
+    order_services: dict[Brokerage, OrderServicePort]
+    quote_services: dict[Brokerage, QuoteServicePort]

--- a/tests/common/service/test_http_service_adapters.py
+++ b/tests/common/service/test_http_service_adapters.py
@@ -1,0 +1,279 @@
+import json
+from datetime import date, datetime
+
+import httpx
+import pytest
+
+from common.api.orders.order_test_util import OrderTestUtil
+from fianchetto_tradebot.common_models.api.orders.cancel_order_request import CancelOrderRequest
+from fianchetto_tradebot.common_models.api.orders.cancel_order_response import CancelOrderResponse
+from fianchetto_tradebot.common_models.api.orders.get_order_request import GetOrderRequest
+from fianchetto_tradebot.common_models.api.orders.get_order_response import GetOrderResponse
+from fianchetto_tradebot.common_models.api.orders.order_metadata import OrderMetadata
+from fianchetto_tradebot.common_models.api.orders.place_order_response import PlaceOrderResponse
+from fianchetto_tradebot.common_models.api.orders.preview_modify_order_request import PreviewModifyOrderRequest
+from fianchetto_tradebot.common_models.api.orders.preview_order_request import PreviewOrderRequest
+from fianchetto_tradebot.common_models.api.quotes.get_tradable_request import GetTradableRequest
+from fianchetto_tradebot.common_models.api.quotes.get_tradable_response import GetTradableResponse
+from fianchetto_tradebot.common_models.api.request_status import RequestStatus
+from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.common_models.finance.amount import Amount
+from fianchetto_tradebot.common_models.finance.currency import Currency
+from fianchetto_tradebot.common_models.finance.equity import Equity
+from fianchetto_tradebot.common_models.finance.option import Option
+from fianchetto_tradebot.common_models.finance.option_type import OptionType
+from fianchetto_tradebot.common_models.finance.price import Price
+from fianchetto_tradebot.common_models.order.order import Order
+from fianchetto_tradebot.common_models.order.order_price_type import OrderPriceType
+from fianchetto_tradebot.common_models.order.order_status import OrderStatus
+from fianchetto_tradebot.common_models.order.order_type import OrderType
+from fianchetto_tradebot.common_models.order.placed_order import PlacedOrder
+from fianchetto_tradebot.common_models.order.placed_order_details import PlacedOrderDetails
+from fianchetto_tradebot.server.common.service.adapters import (
+    DEFAULT_ORDERS_SERVICE_URL,
+    DEFAULT_QUOTES_SERVICE_URL,
+    ORDERS_SERVICE_URL_ENV_VAR,
+    QUOTES_SERVICE_URL_ENV_VAR,
+    HttpOrderServiceAdapter,
+    HttpQuoteServiceAdapter,
+    HttpServiceAdapterError,
+    ServiceAdapters,
+    build_http_service_adapters,
+    load_http_service_adapter_config,
+)
+
+
+def _client(handler) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _json_response(model) -> httpx.Response:
+    return httpx.Response(200, json=model.model_dump(mode="json"))
+
+
+def _order_metadata(account_id: str = "acct-1") -> OrderMetadata:
+    return OrderMetadata(order_type=OrderType.SPREADS, account_id=account_id, client_order_id="client-1")
+
+
+def _order() -> Order:
+    return OrderTestUtil.build_spread_order()
+
+
+def _preview_order_request(account_id: str = "acct-1") -> PreviewOrderRequest:
+    return PreviewOrderRequest(order_metadata=_order_metadata(account_id), order=_order())
+
+
+def _place_order_response(order_id: str = "order-1") -> PlaceOrderResponse:
+    return PlaceOrderResponse(
+        order_metadata=_order_metadata(),
+        preview_id="preview-1",
+        order_id=order_id,
+        order=_order(),
+    )
+
+
+def _get_order_response(order_id: str = "order-1") -> GetOrderResponse:
+    placed_order_details = PlacedOrderDetails(
+        account_id="acct-1",
+        brokerage_order_id=order_id,
+        status=OrderStatus.OPEN,
+        order_placed_time=datetime(2026, 1, 1, 12, 0, 0),
+        current_market_price=Price(bid=1.0, ask=1.2),
+    )
+    return GetOrderResponse(
+        placed_order=PlacedOrder(order=_order(), placed_order_details=placed_order_details)
+    )
+
+
+def test_http_adapter_config_reads_generic_service_urls():
+    config = load_http_service_adapter_config(
+        {
+            ORDERS_SERVICE_URL_ENV_VAR: "http://orders:8080",
+            QUOTES_SERVICE_URL_ENV_VAR: "http://quotes:8081",
+        }
+    )
+
+    assert config.orders_base_url == "http://orders:8080"
+    assert config.quotes_base_url == "http://quotes:8081"
+
+
+def test_http_adapter_config_defaults_to_local_service_urls():
+    config = load_http_service_adapter_config({})
+
+    assert config.orders_base_url == DEFAULT_ORDERS_SERVICE_URL
+    assert config.quotes_base_url == DEFAULT_QUOTES_SERVICE_URL
+
+
+def test_build_http_service_adapters_creates_port_adapters_from_shared_container():
+    config = load_http_service_adapter_config(
+        {
+            ORDERS_SERVICE_URL_ENV_VAR: "http://orders:8080",
+            QUOTES_SERVICE_URL_ENV_VAR: "http://quotes:8081",
+        }
+    )
+
+    service_adapters = build_http_service_adapters([Brokerage.ETRADE, Brokerage.IBKR], config)
+
+    assert isinstance(service_adapters, ServiceAdapters)
+    assert isinstance(service_adapters.order_services[Brokerage.ETRADE], HttpOrderServiceAdapter)
+    assert isinstance(service_adapters.quote_services[Brokerage.ETRADE], HttpQuoteServiceAdapter)
+    assert isinstance(service_adapters.order_services[Brokerage.IBKR], HttpOrderServiceAdapter)
+    assert isinstance(service_adapters.quote_services[Brokerage.IBKR], HttpQuoteServiceAdapter)
+
+
+def test_http_order_adapter_gets_order():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/api/v1/etrade/accounts/acct-1/orders/order-1"
+        return _json_response(_get_order_response())
+
+    adapter = HttpOrderServiceAdapter(
+        brokerage=Brokerage.ETRADE,
+        orders_base_url="http://orders:8080",
+        client=_client(handler),
+    )
+
+    response = adapter.get_order(GetOrderRequest(account_id="acct-1", order_id="order-1"))
+
+    assert response.placed_order.placed_order_details.brokerage_order_id == "order-1"
+
+
+def test_http_order_adapter_cancels_order():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "DELETE"
+        assert request.url.path == "/api/v1/etrade/accounts/acct-1/orders/order-1"
+        return _json_response(
+            CancelOrderResponse(
+                order_id="order-1",
+                cancel_time="2026-01-01T12:00:00",
+                messages=[],
+                request_status=RequestStatus.SUCCESS,
+            )
+        )
+
+    adapter = HttpOrderServiceAdapter(
+        brokerage=Brokerage.ETRADE,
+        orders_base_url="http://orders:8080",
+        client=_client(handler),
+    )
+
+    response = adapter.cancel_order(CancelOrderRequest(account_id="acct-1", order_id="order-1"))
+
+    assert response.order_id == "order-1"
+
+
+def test_http_order_adapter_preview_and_place_uses_json_mode_payload():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/api/v1/etrade/accounts/acct-1/orders/preview_and_place"
+        payload = json.loads(request.content)
+        assert payload["order_metadata"]["order_type"] == "SPREADS"
+        assert payload["order"]["order_lines"][0]["tradable"]["expiry"] == "2025-01-31"
+        assert payload["order"]["order_price"]["order_price_type"] == "NET_CREDIT"
+        return _json_response(_place_order_response())
+
+    adapter = HttpOrderServiceAdapter(
+        brokerage=Brokerage.ETRADE,
+        orders_base_url="http://orders:8080/",
+        client=_client(handler),
+    )
+
+    response = adapter.preview_and_place_order(_preview_order_request())
+
+    assert response.order_id == "order-1"
+
+
+def test_http_order_adapter_modifies_order_using_path_order_id():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PUT"
+        assert request.url.path == "/api/v1/etrade/accounts/acct-1/orders/order-1"
+        payload = json.loads(request.content)
+        assert payload["order_id_to_modify"] == "order-1"
+        return _json_response(_place_order_response(order_id="order-2"))
+
+    adapter = HttpOrderServiceAdapter(
+        brokerage=Brokerage.ETRADE,
+        orders_base_url="http://orders:8080",
+        client=_client(handler),
+    )
+    request = PreviewModifyOrderRequest(
+        order_metadata=_order_metadata(),
+        order=_order(),
+        order_id_to_modify="order-1",
+    )
+
+    response = adapter.modify_order(request)
+
+    assert response.order_id == "order-2"
+
+
+def test_http_quote_adapter_gets_equity_quote():
+    tradable = Equity(ticker="GE")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/api/v1/etrade/quotes/tradable/GE"
+        return _json_response(
+            GetTradableResponse(
+                tradable=tradable,
+                current_price=Price(bid=100, ask=101),
+                volume=1000,
+            )
+        )
+
+    adapter = HttpQuoteServiceAdapter(
+        brokerage=Brokerage.ETRADE,
+        quotes_base_url="http://quotes:8081",
+        client=_client(handler),
+    )
+
+    response = adapter.get_tradable_quote(GetTradableRequest(tradable=tradable))
+
+    assert response.tradable == tradable
+    assert response.current_price.bid == 100
+
+
+def test_http_quote_adapter_gets_option_quote_with_encoded_symbol():
+    tradable = Option(
+        equity=Equity(ticker="GE"),
+        type=OptionType.PUT,
+        strike=Amount(whole=25, part=0, currency=Currency.US_DOLLARS),
+        expiry=date(2026, 1, 16),
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "GE%3A2026%3A1%3A16%3APUT%3A25.0" in str(request.url)
+        return _json_response(
+            GetTradableResponse(
+                tradable=tradable,
+                current_price=Price(bid=1.0, ask=1.2),
+                volume=100,
+            )
+        )
+
+    adapter = HttpQuoteServiceAdapter(
+        brokerage=Brokerage.ETRADE,
+        quotes_base_url="http://quotes:8081",
+        client=_client(handler),
+    )
+
+    response = adapter.get_tradable_quote(GetTradableRequest(tradable=tradable))
+
+    assert response.tradable == tradable
+
+
+def test_http_adapter_raises_application_error_for_http_failure():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="service unavailable")
+
+    adapter = HttpQuoteServiceAdapter(
+        brokerage=Brokerage.ETRADE,
+        quotes_base_url="http://quotes:8081",
+        client=_client(handler),
+    )
+
+    with pytest.raises(HttpServiceAdapterError) as exc_info:
+        adapter.get_tradable_quote(GetTradableRequest(tradable=Equity(ticker="GE")))
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.response_text == "service unavailable"

--- a/tests/common/service/test_local_service_adapters.py
+++ b/tests/common/service/test_local_service_adapters.py
@@ -7,6 +7,7 @@ from fianchetto_tradebot.server.common.brokerage.connector import Connector
 from fianchetto_tradebot.server.common.service.adapters import (
     LocalOrderServiceAdapter,
     LocalQuoteServiceAdapter,
+    ServiceAdapters,
     build_local_service_adapters,
 )
 from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
@@ -63,6 +64,7 @@ def test_local_quote_adapter_delegates_to_wrapped_service():
 def test_build_local_service_adapters_creates_etrade_port_adapters():
     local_services = build_local_service_adapters({Brokerage.ETRADE: FakeConnector()})
 
+    assert isinstance(local_services, ServiceAdapters)
     order_service = local_services.order_services[Brokerage.ETRADE]
     quote_service = local_services.quote_services[Brokerage.ETRADE]
 


### PR DESCRIPTION
## Summary

- Add HTTP-backed order and quote service adapters that implement the same ports as local mode.
- Add shared HTTP adapter request/error handling and generic service URL config.
- Use deployment-neutral env vars: `TRADEBOT_ORDERS_SERVICE_URL` and `TRADEBOT_QUOTES_SERVICE_URL`.
- Keep code defaults pointed at local dev service ports: `http://localhost:8080` and `http://localhost:8081`.
- Serialize outbound Pydantic request payloads with `model_dump(mode="json")`.
- Add a shared `ServiceAdapters` container and symmetric `build_http_service_adapters(...)` factory alongside `build_local_service_adapters(...)`.
- Document that HTTP adapters construct URLs with route path values while FastAPI handlers may remain body-focused.
- Add HTTP adapter tests with `httpx.MockTransport` for success paths, JSON-mode payloads, encoded quote symbols, env config, factory symmetry, and HTTP failures.

## Validation

- `/tmp/tradebot-fia139-venv/bin/python -m pytest tests/common/service/test_http_service_adapters.py tests/common/service/test_local_service_adapters.py tests/common/service/test_service_ports.py` - 16 passed
- `/tmp/tradebot-fia139-venv/bin/python -m pytest` - 163 passed, 4 skipped

Note: local validation used the existing throwaway Python 3.12 venv with `--ignore-requires-python` because this machine does not have Python 3.14 installed. GitHub Actions will run the canonical Python 3.14 workflow.
