### PR TITLE
FIA-147: Configure E*Trade simulator endpoints

### DIFF
--- a/docs/etrade-simulator-contract.md
+++ b/docs/etrade-simulator-contract.md
@@ -83,6 +83,51 @@ This is a real FastAPI/uvicorn process, but it is still not part of the default
 unit test suite. Docker Compose wiring and real-process smoke tests are tracked
 separately.
 
+## TradeBot Connector Configuration
+
+TradeBot E*Trade services should keep production behavior unchanged by default:
+they load OAuth credentials and use the E*Trade base URL stored with those
+credentials.
+
+Simulator-backed deployments should supply fake E*Trade credentials and point
+the connector at the simulator endpoint. For example, the credential cache can
+contain non-secret placeholder values:
+
+```json
+{
+  "consumer_key": "simulator-consumer-key",
+  "consumer_secret": "simulator-consumer-secret",
+  "access_token": "simulator-access-token",
+  "access_token_secret": "simulator-access-token-secret",
+  "request_token": "simulator-request-token",
+  "request_token_secret": "simulator-request-token-secret",
+  "base_url": "http://etrade-sim:8090"
+}
+```
+
+This preserves the normal OAuth-shaped connector/session path while avoiding
+live brokerage credentials. The simulator ignores the fake signature material,
+but the credential document is still validated: required OAuth fields must be
+present and non-empty, request-token fields must be present and either non-empty
+or `null`, and `base_url` must be an `http` or `https` URL.
+
+`TRADEBOT_ETRADE_API_BASE_URL` can override the cached E*Trade-compatible HTTP
+endpoint at runtime:
+
+```bash
+TRADEBOT_ETRADE_API_BASE_URL=http://etrade-sim:8090
+```
+
+Use a Docker/Kubernetes service name such as `http://etrade-sim:8090` inside a
+service network, or `http://127.0.0.1:8090` for local process testing.
+
+Base URL precedence is explicit:
+
+1. `TRADEBOT_ETRADE_API_BASE_URL`
+2. `base_url` in the credential cache
+3. legacy standalone `base_url.json`
+4. interactive OAuth establishment
+
 ## Validation Layers
 
 - Unit/parser tests prove the simulator-shaped payloads still parse into domain

--- a/src/fianchetto_tradebot/server/common/brokerage/etrade/config.example.ini
+++ b/src/fianchetto_tradebot/server/common/brokerage/etrade/config.example.ini
@@ -2,6 +2,11 @@
 SANDBOX_BASE_URL=https://apisb.etrade.com
 PROD_BASE_URL=https://api.etrade.com
 
+# Runtime deployment endpoint overrides live in environment variables, not this
+# credential file. Simulator-backed deployment can use fake credential-cache
+# values plus:
+# TRADEBOT_ETRADE_API_BASE_URL=http://etrade-sim:8090
+
 [SANDBOX]
 SANDBOX_API_KEY=<SANDBOX_API_KEY>
 SANDBOX_API_SECRET=<SANDBOX_API_SECRET_KEY>

--- a/src/fianchetto_tradebot/server/common/brokerage/etrade/etrade_connector.py
+++ b/src/fianchetto_tradebot/server/common/brokerage/etrade/etrade_connector.py
@@ -5,6 +5,8 @@ import logging
 import os
 import webbrowser
 from pathlib import Path
+from typing import Mapping
+from urllib.parse import urlparse
 
 from aioauth_client import OAuth1Client
 from rauth import OAuth1Service, OAuth1Session
@@ -26,6 +28,18 @@ DEFAULT_CREDENTIALS_FILE = os.path.join(BROKERAGE_STATE_DIR, "connection.json")
 DEFAULT_SESSION_FILE = DEFAULT_CREDENTIALS_FILE
 DEFAULT_ASYNC_SESSION_FILE = DEFAULT_CREDENTIALS_FILE
 DEFAULT_ETRADE_BASE_URL_FILE = os.path.join(BROKERAGE_STATE_DIR, "base_url.json")
+ETRADE_API_BASE_URL_ENV_VAR = "TRADEBOT_ETRADE_API_BASE_URL"
+REQUIRED_CREDENTIAL_FIELDS = (
+    "consumer_key",
+    "consumer_secret",
+    "access_token",
+    "access_token_secret",
+    "base_url",
+)
+OPTIONAL_CREDENTIAL_FIELDS = (
+    "request_token",
+    "request_token_secret",
+)
 
 # For debugging
 REQUEST_TOKEN_FILE = os.path.join(BROKERAGE_STATE_DIR, "request_token.json")
@@ -37,9 +51,16 @@ logger = logging.getLogger(__name__)
 
 
 class ETradeConnector(Connector):
-    def __init__(self, config_file=DEFAULT_CONFIG_FILE, session_file=DEFAULT_SESSION_FILE, async_session_file=DEFAULT_ASYNC_SESSION_FILE, base_url_file=DEFAULT_ETRADE_BASE_URL_FILE):
+    def __init__(
+            self,
+            config_file=DEFAULT_CONFIG_FILE,
+            session_file=DEFAULT_SESSION_FILE,
+            async_session_file=DEFAULT_ASYNC_SESSION_FILE,
+            base_url_file=DEFAULT_ETRADE_BASE_URL_FILE,
+            env: Mapping[str, str] | None = None):
         self.brokerage = BROKERAGE_NAME
         self.config_file = config_file
+        self.env = env if env is not None else os.environ
         # session_file/async_session_file are kept as constructor aliases for older callers.
         self.credentials_file = session_file
         self.session_file = session_file
@@ -48,19 +69,57 @@ class ETradeConnector(Connector):
         self.session, self.async_session, self.base_url = self.load_connection()
 
     def load_base_url(self) -> str:
-        if ETradeConnector.is_file_still_valid(self.credentials_file):
-            return ETradeConnector._deserialize_connection_credentials(self.credentials_file)["base_url"]
+        credentials = self._load_valid_connection_credentials()
+        if credentials:
+            return self._resolve_base_url(credentials_base_url=credentials["base_url"])
 
-        if ETradeConnector.is_file_still_valid(self.base_url_file):
-            return ETradeConnector.deserialize_base_url(self.base_url_file)
+        standalone_base_url = self._load_valid_standalone_base_url()
+        if standalone_base_url:
+            return self._resolve_base_url(standalone_base_url=standalone_base_url)
 
         return self.establish_connection()[2]
 
     def load_connection(self) -> (OAuth1Session, OAuth1Client, str):
-        if ETradeConnector.is_file_still_valid(self.credentials_file):
-            return ETradeConnector._build_connection_from_credentials_file(self.credentials_file)
+        credentials = self._load_valid_connection_credentials()
+        if credentials:
+            base_url = self._resolve_base_url(
+                credentials_base_url=credentials["base_url"],
+            )
+            return ETradeConnector._build_connection_from_credentials(credentials, base_url)
 
         return self.establish_connection()
+
+    def _resolve_base_url(
+            self,
+            credentials_base_url: str | None = None,
+            standalone_base_url: str | None = None) -> str | None:
+        """Resolve endpoint precedence: env override, credential cache, then standalone file."""
+        configured_base_url = self._configured_base_url()
+        if configured_base_url:
+            return configured_base_url
+        if credentials_base_url:
+            return ETradeConnector._normalize_base_url(credentials_base_url, "base_url")
+        if standalone_base_url:
+            return ETradeConnector._normalize_base_url(standalone_base_url, "base_url")
+        return None
+
+    def _load_valid_connection_credentials(self) -> dict | None:
+        if not ETradeConnector.is_file_still_valid(self.credentials_file):
+            return None
+        return ETradeConnector._validate_connection_credentials(
+            ETradeConnector._deserialize_connection_credentials(self.credentials_file)
+        )
+
+    def _load_valid_standalone_base_url(self) -> str | None:
+        if not ETradeConnector.is_file_still_valid(self.base_url_file):
+            return None
+        return ETradeConnector.deserialize_base_url(self.base_url_file)
+
+    def _configured_base_url(self) -> str | None:
+        raw_base_url = self.env.get(ETRADE_API_BASE_URL_ENV_VAR)
+        if not raw_base_url:
+            return None
+        return ETradeConnector._normalize_base_url(raw_base_url, ETRADE_API_BASE_URL_ENV_VAR)
 
     def establish_connection(self) -> (OAuth1Session, OAuth1Client, str):
         config.read(self.config_file)
@@ -182,6 +241,7 @@ class ETradeConnector(Connector):
         ETradeConnector._serialize_json_value(token_secret, OAUTH_TOKEN_SECRET_FILE)
 
     def serialize_base_url(self, base_url: str):
+        base_url = ETradeConnector._normalize_base_url(base_url, "base_url")
         ETradeConnector._serialize_json_value(base_url, self.base_url_file)
 
     @staticmethod
@@ -210,7 +270,10 @@ class ETradeConnector(Connector):
 
     @staticmethod
     def deserialize_base_url(input=DEFAULT_ETRADE_BASE_URL_FILE) -> str:
-        return ETradeConnector._deserialize_json_value(input)
+        return ETradeConnector._normalize_base_url(
+            ETradeConnector._deserialize_json_value(input),
+            "base_url",
+        )
 
     @staticmethod
     def is_file_still_valid(input, max_age=datetime.timedelta(hours=1)):
@@ -242,6 +305,7 @@ class ETradeConnector(Connector):
 
     @staticmethod
     def _serialize_connection_credentials(credentials: dict, output_file):
+        credentials = ETradeConnector._validate_connection_credentials(credentials)
         ETradeConnector._ensure_private_parent(output_file)
         with open(output_file, "w") as f:
             json.dump(credentials, f)
@@ -253,10 +317,19 @@ class ETradeConnector(Connector):
             return json.load(f)
 
     @staticmethod
-    def _build_connection_from_credentials_file(input_file) -> (OAuth1Session, OAuth1Client, str):
-        credentials = ETradeConnector._deserialize_connection_credentials(input_file)
-        base_url = credentials["base_url"]
+    def _build_connection_from_credentials_file(input_file, base_url_override: str | None = None) -> (OAuth1Session, OAuth1Client, str):
+        credentials = ETradeConnector._validate_connection_credentials(
+            ETradeConnector._deserialize_connection_credentials(input_file)
+        )
+        base_url = (
+            ETradeConnector._normalize_base_url(base_url_override, ETRADE_API_BASE_URL_ENV_VAR)
+            if base_url_override
+            else credentials["base_url"]
+        )
+        return ETradeConnector._build_connection_from_credentials(credentials, base_url)
 
+    @staticmethod
+    def _build_connection_from_credentials(credentials: dict, base_url: str) -> (OAuth1Session, OAuth1Client, str):
         service = OAuth1Service(
             name="etrade",
             consumer_key=credentials["consumer_key"],
@@ -286,6 +359,48 @@ class ETradeConnector(Connector):
             signature_type="query")
 
         return session, async_session, base_url
+
+    @staticmethod
+    def _validate_connection_credentials(credentials: dict) -> dict:
+        if not isinstance(credentials, dict):
+            raise ValueError("E*Trade connection credentials must be a JSON object")
+
+        normalized_credentials = dict(credentials)
+        for field in REQUIRED_CREDENTIAL_FIELDS:
+            ETradeConnector._require_non_empty_string(normalized_credentials, field)
+
+        for field in OPTIONAL_CREDENTIAL_FIELDS:
+            if field not in normalized_credentials:
+                raise ValueError(f"E*Trade connection credentials must include {field}")
+            value = normalized_credentials[field]
+            if value is not None:
+                ETradeConnector._require_non_empty_string(normalized_credentials, field)
+
+        normalized_credentials["base_url"] = ETradeConnector._normalize_base_url(
+            normalized_credentials["base_url"],
+            "base_url",
+        )
+        return normalized_credentials
+
+    @staticmethod
+    def _require_non_empty_string(credentials: dict, field: str) -> None:
+        if field not in credentials:
+            raise ValueError(f"E*Trade connection credentials must include {field}")
+        value = credentials[field]
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"E*Trade connection credential {field} must be a non-empty string")
+
+    @staticmethod
+    def _normalize_base_url(raw_base_url: str, source: str) -> str:
+        if not isinstance(raw_base_url, str) or not raw_base_url.strip():
+            raise ValueError(f"E*Trade {source} must be a non-empty URL")
+
+        base_url = raw_base_url.strip().rstrip("/")
+        parsed_url = urlparse(base_url)
+        if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+            raise ValueError(f"E*Trade {source} must be an http(s) URL")
+
+        return base_url
 
     @staticmethod
     def _ensure_private_parent(output_file):

--- a/tests/common/api/etrade/test_etrade_connector_config.py
+++ b/tests/common/api/etrade/test_etrade_connector_config.py
@@ -1,0 +1,224 @@
+import json
+import stat
+from unittest.mock import patch
+
+import pytest
+from aioauth_client import OAuth1Client
+from rauth import OAuth1Session
+
+from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import (
+    ETRADE_API_BASE_URL_ENV_VAR,
+    ETradeConnector,
+)
+
+
+def test_connector_uses_sensible_fake_credentials_with_simulator_endpoint(tmp_path):
+    # Given
+    # A fake credential document shaped like the real E*Trade connection cache.
+    credentials_file = tmp_path / "connection.json"
+    _write_credentials(credentials_file, base_url="http://etrade-sim:8090/")
+
+    # When
+    # The connector is constructed with the fake credential document.
+    connector = ETradeConnector(
+        config_file=str(tmp_path / "missing-config.ini"),
+        session_file=str(credentials_file),
+        async_session_file=str(credentials_file),
+        base_url_file=str(tmp_path / "missing-base-url.json"),
+        env={},
+    )
+
+    # Then
+    # It targets the simulator with the same OAuth-shaped sessions production uses.
+    assert connector.base_url == "http://etrade-sim:8090"
+    assert connector.load_base_url() == "http://etrade-sim:8090"
+    assert isinstance(connector.session, OAuth1Session)
+    assert isinstance(connector.async_session, OAuth1Client)
+
+
+def test_connector_accepts_serialized_session_credentials_without_request_tokens(tmp_path):
+    # Given
+    # The credential shape produced by serialize_session for an already-authorized session.
+    credentials_file = tmp_path / "connection.json"
+    _write_credentials(
+        credentials_file,
+        base_url="http://etrade-sim:8090",
+        request_token=None,
+        request_token_secret=None,
+    )
+
+    # When
+    # The connector rebuilds the sessions.
+    connector = ETradeConnector(
+        config_file=str(tmp_path / "missing-config.ini"),
+        session_file=str(credentials_file),
+        async_session_file=str(credentials_file),
+        base_url_file=str(tmp_path / "missing-base-url.json"),
+        env={},
+    )
+
+    # Then
+    # Required credential fields are still validated while legacy request-token values remain optional.
+    assert connector.base_url == "http://etrade-sim:8090"
+    assert connector.async_session.oauth_token == "simulator-access-token"
+
+
+def test_connector_env_base_url_overrides_stored_credential_endpoint(tmp_path):
+    # Given
+    # Valid OAuth-shaped credentials from one endpoint and an explicit runtime endpoint override.
+    credentials_file = tmp_path / "connection.json"
+    _write_credentials(credentials_file, base_url="https://api.etrade.com")
+
+    # When
+    # The connector is created with an environment base URL override.
+    connector = ETradeConnector(
+        session_file=str(credentials_file),
+        async_session_file=str(credentials_file),
+        base_url_file=str(tmp_path / "base-url.json"),
+        env={ETRADE_API_BASE_URL_ENV_VAR: "http://localhost:8090/"},
+    )
+
+    # Then
+    # The stored credentials are reused, but service calls target the configured endpoint.
+    assert connector.base_url == "http://localhost:8090"
+    assert connector.async_session.base_url == "http://localhost:8090"
+    assert stat.S_IMODE(credentials_file.stat().st_mode) == 0o600
+
+
+def test_base_url_precedence_is_env_then_credentials_then_standalone_file(tmp_path):
+    # Given
+    # All supported base-url sources exist.
+    credentials_file = tmp_path / "connection.json"
+    standalone_base_url_file = tmp_path / "base-url.json"
+    _write_credentials(credentials_file, base_url="https://credential-cache.example.test")
+    _write_standalone_base_url(standalone_base_url_file, "https://standalone.example.test")
+
+    # When / Then
+    # Runtime configuration takes precedence over cached credential and legacy standalone values.
+    assert _connector_for_base_url_resolution(
+        credentials_file=credentials_file,
+        standalone_base_url_file=standalone_base_url_file,
+        env={ETRADE_API_BASE_URL_ENV_VAR: "http://etrade-sim:8090"},
+    ).load_base_url() == "http://etrade-sim:8090"
+
+    # When / Then
+    # Credential-cache base URL wins when runtime configuration is absent.
+    assert _connector_for_base_url_resolution(
+        credentials_file=credentials_file,
+        standalone_base_url_file=standalone_base_url_file,
+        env={},
+    ).load_base_url() == "https://credential-cache.example.test"
+
+    # When / Then
+    # The legacy standalone base-url file is a final cached fallback.
+    assert _connector_for_base_url_resolution(
+        credentials_file=tmp_path / "missing-connection.json",
+        standalone_base_url_file=standalone_base_url_file,
+        env={},
+    ).load_base_url() == "https://standalone.example.test"
+
+
+def test_connector_rejects_missing_required_credential_field(tmp_path):
+    credentials_file = tmp_path / "connection.json"
+    credentials = _credentials_dict()
+    del credentials["consumer_key"]
+
+    with pytest.raises(ValueError, match="consumer_key"):
+        ETradeConnector._serialize_connection_credentials(credentials, credentials_file)
+
+
+def test_connector_rejects_blank_credential_value(tmp_path):
+    credentials_file = tmp_path / "connection.json"
+    credentials = _credentials_dict(access_token=" ")
+
+    with pytest.raises(ValueError, match="access_token"):
+        ETradeConnector._serialize_connection_credentials(credentials, credentials_file)
+
+
+def test_connector_rejects_invalid_credential_base_url(tmp_path):
+    credentials_file = tmp_path / "connection.json"
+    credentials = _credentials_dict(base_url="etrade-sim:8090")
+
+    with pytest.raises(ValueError, match="http\\(s\\) URL"):
+        ETradeConnector._serialize_connection_credentials(credentials, credentials_file)
+
+
+def test_connector_rejects_manually_authored_invalid_credential_file(tmp_path):
+    credentials_file = tmp_path / "connection.json"
+    credentials_file.write_text(json.dumps(_credentials_dict(access_token="")))
+
+    with pytest.raises(ValueError, match="access_token"):
+        ETradeConnector._build_connection_from_credentials_file(credentials_file)
+
+
+def test_connector_rejects_invalid_env_base_url(tmp_path):
+    credentials_file = tmp_path / "connection.json"
+    _write_credentials(credentials_file, base_url="http://etrade-sim:8090")
+
+    with pytest.raises(ValueError, match=ETRADE_API_BASE_URL_ENV_VAR):
+        ETradeConnector(
+            session_file=str(credentials_file),
+            async_session_file=str(credentials_file),
+            base_url_file=str(tmp_path / "base-url.json"),
+            env={ETRADE_API_BASE_URL_ENV_VAR: "etrade-sim:8090"},
+        )
+
+
+def test_connector_rejects_invalid_standalone_base_url_file(tmp_path):
+    connector = object.__new__(ETradeConnector)
+    connector.base_url_file = str(tmp_path / "base-url.json")
+
+    with pytest.raises(ValueError, match="http\\(s\\) URL"):
+        connector.serialize_base_url("etrade-sim:8090")
+
+
+def test_configured_endpoint_does_not_skip_credentials(tmp_path):
+    # Given
+    # An endpoint override but no credential document.
+    env = {ETRADE_API_BASE_URL_ENV_VAR: "http://etrade-sim:8090"}
+
+    # When / Then
+    # The connector still falls through to the normal connection establishment path.
+    with patch.object(ETradeConnector, "establish_connection", side_effect=RuntimeError("credentials required")):
+        with pytest.raises(RuntimeError, match="credentials required"):
+            ETradeConnector(
+                config_file=str(tmp_path / "missing-config.ini"),
+                session_file=str(tmp_path / "missing-connection.json"),
+                async_session_file=str(tmp_path / "missing-connection.json"),
+                base_url_file=str(tmp_path / "missing-base-url.json"),
+                env=env,
+            )
+
+
+def _write_credentials(credentials_file, **overrides) -> None:
+    connector = object.__new__(ETradeConnector)
+    connector.credentials_file = str(credentials_file)
+    connector.serialize_connection_credentials(**_credentials_dict(**overrides))
+
+
+def _write_standalone_base_url(base_url_file, base_url: str) -> None:
+    connector = object.__new__(ETradeConnector)
+    connector.base_url_file = str(base_url_file)
+    connector.serialize_base_url(base_url)
+
+
+def _connector_for_base_url_resolution(credentials_file, standalone_base_url_file, env) -> ETradeConnector:
+    connector = object.__new__(ETradeConnector)
+    connector.credentials_file = str(credentials_file)
+    connector.base_url_file = str(standalone_base_url_file)
+    connector.env = env
+    return connector
+
+
+def _credentials_dict(**overrides) -> dict:
+    credentials = {
+        "consumer_key": "simulator-consumer-key",
+        "consumer_secret": "simulator-consumer-secret",
+        "access_token": "simulator-access-token",
+        "access_token_secret": "simulator-access-token-secret",
+        "request_token": "simulator-request-token",
+        "request_token_secret": "simulator-request-token-secret",
+        "base_url": "http://etrade-sim:8090",
+    }
+    credentials.update(overrides)
+    return credentials

--- a/tests/common/api/orders/etrade/test_etrade_order_service.py
+++ b/tests/common/api/orders/etrade/test_etrade_order_service.py
@@ -1,11 +1,9 @@
 import os
 import pickle
 import stat
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
-from aioauth_client import OAuth1Client
-from rauth import OAuth1Session
 
 from fianchetto_tradebot.server.common.api.orders.etrade.etrade_order_service import ETradeOrderService
 from fianchetto_tradebot.common_models.api.orders.order_metadata import OrderMetadata
@@ -15,13 +13,7 @@ from fianchetto_tradebot.common_models.api.orders.preview_order_response import 
 from fianchetto_tradebot.server.common.api.http_status_code import HttpStatusCode
 from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import ETradeConnector, DEFAULT_ETRADE_BASE_URL_FILE
 from fianchetto_tradebot.common_models.finance.amount import Amount
-from fianchetto_tradebot.common_models.finance.currency import Currency
-from fianchetto_tradebot.common_models.finance.equity import Equity
 from fianchetto_tradebot.common_models.order.executed_order import ExecutedOrder
-from fianchetto_tradebot.common_models.order.action import Action
-from fianchetto_tradebot.common_models.order.expiry.good_for_day import GoodForDay
-from fianchetto_tradebot.common_models.order.order import Order
-from fianchetto_tradebot.common_models.order.order_line import OrderLine
 from fianchetto_tradebot.common_models.order.order_price import OrderPrice
 from fianchetto_tradebot.common_models.order.order_price_type import OrderPriceType
 from fianchetto_tradebot.common_models.order.order_type import OrderType
@@ -42,6 +34,7 @@ SPREAD_ORDER_METADATA = OrderMetadata(order_type=OrderType.SPREADS, account_id=A
 EXPECTED_ORDER_PRICE = OrderPrice(order_price_type=OrderPriceType.NET_CREDIT, price=Amount(whole=2, part=49))
 
 PLACED_ORDER_ID = 81117
+FAKE_ETRADE_BASE_URL = "https://api.example.test"
 
 SPREAD_PREVIEW_ORDER_RESPONSE_FILE = os.path.join(os.path.dirname(__file__), "./resources/output_preview_order_spread")
 SPREAD_PLACE_ORDER_RESPONSE_FILE = os.path.join(os.path.dirname(__file__), "./resources/output_place_order_spread")
@@ -58,15 +51,8 @@ class DummyJsonResponse:
         return self._body
 
 @pytest.fixture
-def preview_request()->PreviewOrderRequest:
-    tradable = Equity(ticker="GE", company_name="General Electric")
-    order_line = OrderLine(tradable=tradable, action=Action.BUY, quantity=3)
-    order_price = OrderPrice(order_price_type=OrderPriceType.NET_DEBIT, price=Amount(whole=100,part=0, currency=Currency.US_DOLLARS))
-    order = Order(expiry=GoodForDay(), order_lines=[order_line], order_price=order_price)
-
-    order_metadata: OrderMetadata = OrderMetadata(order_type=OrderType.EQ, account_id=ACCOUNT_ID, client_order_id=CLIENT_ORDER_ID)
-
-    return PreviewOrderRequest(order_metadata=order_metadata, order=order)
+def spread_preview_request()->PreviewOrderRequest:
+    return PreviewOrderRequest(order_metadata=SPREAD_ORDER_METADATA, order=SPREAD_ORDER)
 
 @pytest.fixture
 def preview_order_spread_response():
@@ -77,12 +63,11 @@ def place_order_spread_response():
     return _read_input(SPREAD_PLACE_ORDER_RESPONSE_FILE)
 
 @pytest.fixture
-@patch('rauth.OAuth1Session')
-@patch('aioauth_client.OAuth1Client')
-def connector(session: OAuth1Session, async_session: OAuth1Client):
-    # build a connector that gives back a mock session
-    connector: ETradeConnector = ETradeConnector()
-    connector.load_connection = MagicMock(return_value = (session, async_session, DEFAULT_ETRADE_BASE_URL_FILE))
+def connector():
+    session = MagicMock()
+    async_session = MagicMock()
+    connector = MagicMock(spec=ETradeConnector)
+    connector.load_connection.return_value = (session, async_session, FAKE_ETRADE_BASE_URL)
     return connector
 
 @pytest.fixture
@@ -90,33 +75,31 @@ def order_service(connector):
     # TODO: Set up the service that will provide mock responses to given requests
     return ETradeOrderService(connector)
 
-@pytest.mark.skip("Currently failing strange pydantic parsing")
 def test_process_spread_preview_order_response(preview_order_spread_response):
     response: PreviewOrderResponse = ETradeOrderService._parse_preview_order_response(preview_order_spread_response, SPREAD_ORDER_METADATA)
     assert SPREAD_ORDER_PREVIEW_ID == str(response.preview_id)
     assert SPREAD_ORDER_TOTAL_ORDER_VALUE == response.preview_order_info.total_order_value
     assert SPREAD_ORDER_ESTIMATED_COMMISSION == response.preview_order_info.estimated_commission
 
-@pytest.mark.skip("Currently failing strange pydantic parsing")
 def test_process_spread_place_order_response_id_parsed(place_order_spread_response):
     response: PlaceOrderResponse = ETradeOrderService._parse_place_order_response(place_order_spread_response, SPREAD_ORDER_METADATA, SPREAD_ORDER_PREVIEW_ID)
     assert str(PLACED_ORDER_ID) == response.order_id
 
-@pytest.mark.skip("Currently failing strange pydantic parsing")
 def test_process_spread_place_order_response_order_parsed(place_order_spread_response):
     response: PlaceOrderResponse = ETradeOrderService._parse_place_order_response(place_order_spread_response, SPREAD_ORDER_METADATA, SPREAD_ORDER_PREVIEW_ID)
     assert SPREAD_ORDER == response.order
 
-@pytest.mark.skip("Currently failing strange pydantic parsing")
-def test_preview_spread_order(order_service, preview_request, preview_order_spread_response):
+def test_preview_spread_order_posts_spread_preview_request(order_service, spread_preview_request, preview_order_spread_response):
     # Given a mock service
     session = order_service.session
     session.post = MagicMock(return_value = preview_order_spread_response)
 
     # Given a Request
-    response: PreviewOrderResponse = order_service.preview_order(preview_request)
+    response: PreviewOrderResponse = order_service.preview_order(spread_preview_request)
 
     # Assert output makes sense
+    session.post.assert_called_once()
+    assert session.post.call_args.args[0] == f"{FAKE_ETRADE_BASE_URL}/v1/accounts/{ACCOUNT_ID}/orders/preview.json"
     assert SPREAD_ORDER_PREVIEW_ID == str(response.preview_id)
 
 def test_place_order():


### PR DESCRIPTION
## Summary
- add explicit E*Trade connector runtime config for `TRADEBOT_ETRADE_API_BASE_URL`
- centralize base URL resolution with explicit precedence: env override, credential-cache `base_url`, legacy standalone `base_url.json`, then interactive OAuth establishment
- preserve the normal OAuth-shaped connector/session path for simulator-backed deployments by using validated fake credential-cache values instead of a separate no-auth mode
- validate credential-cache documents on write and read: required OAuth fields must be present and non-empty, request-token fields must be present and either non-empty or null, and base URLs must be valid `http`/`https` URLs
- document sensible `simulator-*` credential values, endpoint precedence, and service-test safety in the simulator contract
- unskip stale spread-order parser and preview service tests; the preview test now uses a fake connector and stays in the default unit suite

## Validation
- `/tmp/tradebot-fia147-venv/bin/python -m pytest tests/common/api/etrade/test_etrade_connector_config.py -v`
- `/tmp/tradebot-fia147-venv/bin/python -m pytest tests/common/api/orders/etrade/test_etrade_order_service.py -v -rs`
- `/tmp/tradebot-fia147-venv/bin/python -m pytest -rs`

Latest local result: `192 passed in 0.73s`.

Note: local verification used Python 3.13.3 with `--ignore-requires-python` because this machine does not have Python 3.14 installed; CI remains the canonical Python 3.14 validation.