### PR TITLE
FIA-133: Add Docker POC for TradeBot services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.pytest_cache
+.venv
+__pycache__
+*.py[cod]
+*.egg-info
+build
+dist
+.coverage
+.env
+.env.*
+.idea
+.mypy_cache
+.ruff_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+ARG PYTHON_VERSION=3.14
+FROM python:${PYTHON_VERSION}-slim
+
+ENV PIP_NO_CACHE_DIR=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV TRADEBOT_HEALTHCHECK_PORT=8080
+
+WORKDIR /app
+
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/usr/sbin/nologin" \
+    --no-create-home \
+    --uid 10001 \
+    tradebot
+
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+COPY deploy ./deploy
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install -e .
+
+USER tradebot
+
+EXPOSE 8080 8081 8082 8090
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=20s --retries=5 \
+    CMD python -c "import os, urllib.request; port = os.environ.get('TRADEBOT_HEALTHCHECK_PORT', '8080'); urllib.request.urlopen(f'http://127.0.0.1:{port}/health-check', timeout=2).read()"
+
+CMD ["python", "-m", "fianchetto_tradebot.server.orders.serving.orders_rest_service"]

--- a/deploy/docker/demo-state/etrade/connection.json
+++ b/deploy/docker/demo-state/etrade/connection.json
@@ -1,0 +1,9 @@
+{
+  "consumer_key": "simulator-consumer-key",
+  "consumer_secret": "simulator-consumer-secret",
+  "access_token": "simulator-access-token",
+  "access_token_secret": "simulator-access-token-secret",
+  "request_token": "simulator-request-token",
+  "request_token_secret": "simulator-request-token-secret",
+  "base_url": "http://127.0.0.1:8090"
+}

--- a/docs/docker-poc.md
+++ b/docs/docker-poc.md
@@ -1,0 +1,84 @@
+# Docker POC
+
+FIA-133 introduces one reusable image for local container startup checks. The
+image can run each current REST service by selecting the Python module at
+container start.
+
+This is not the full Docker Compose topology. Compose networking, service DNS,
+and simulator-backed service-to-service checks belong to FIA-136, FIA-148, and
+FIA-149.
+
+## Build
+
+Build from the repository root:
+
+```bash
+docker build -t tradebot:local .
+```
+
+The image defaults to Python 3.14. To test a different image tag temporarily:
+
+```bash
+docker build --build-arg PYTHON_VERSION=3.14 -t tradebot:local .
+```
+
+## Demo State
+
+The REST services currently establish brokerage connectors during service
+construction, before `/health-check` can respond. For credentials-free local
+container startup, point the service at the checked-in demo state directory:
+
+```bash
+FIANCHETTO_TRADEBOT_STATE_DIR=/app/deploy/docker/demo-state
+```
+
+The demo state contains fake OAuth-shaped E*Trade values. They are intentionally
+not live brokerage credentials. A later simulator-backed Compose profile should
+override the API endpoint with service DNS, for example:
+
+```bash
+TRADEBOT_ETRADE_API_BASE_URL=http://etrade-sim:8090
+```
+
+## Run One Service
+
+Orders service:
+
+```bash
+docker run --rm \
+  -e FIANCHETTO_TRADEBOT_STATE_DIR=/app/deploy/docker/demo-state \
+  -e TRADEBOT_HEALTHCHECK_PORT=8080 \
+  -p 8080:8080 \
+  tradebot:local \
+  python -m fianchetto_tradebot.server.orders.serving.orders_rest_service
+```
+
+Quotes service:
+
+```bash
+docker run --rm \
+  -e FIANCHETTO_TRADEBOT_STATE_DIR=/app/deploy/docker/demo-state \
+  -e TRADEBOT_HEALTHCHECK_PORT=8081 \
+  -p 8081:8081 \
+  tradebot:local \
+  python -m fianchetto_tradebot.server.quotes.serving.quotes_rest_service
+```
+
+MOEX service:
+
+```bash
+docker run --rm \
+  -e FIANCHETTO_TRADEBOT_STATE_DIR=/app/deploy/docker/demo-state \
+  -e TRADEBOT_HEALTHCHECK_PORT=8082 \
+  -p 8082:8082 \
+  tradebot:local \
+  python -m fianchetto_tradebot.server.moex.serving.moex_rest_service
+```
+
+Then verify health from the host:
+
+```bash
+curl http://127.0.0.1:8080/health-check
+```
+
+Change the port to match the service under test.


### PR DESCRIPTION
## Summary
- add a reusable Python 3.14 Docker image for TradeBot service processes
- add a small `.dockerignore` for cleaner build context
- add explicit fake E*Trade demo state for credentials-free container startup checks
- document how to build the image and run orders, quotes, and MOEX service containers with health checks

## Scope Notes
- This is the single-service Docker foundation for FIA-133.
- Docker Compose networking belongs to FIA-136.
- Simulator-backed Compose wiring belongs to FIA-148.
- Docker-required pytest smoke tests belong to FIA-149.

## Validation
- `docker build -t tradebot:fia-133 .`
- orders container: `curl http://127.0.0.1:18080/health-check` -> `"ORDERS Service Up"`
- quotes container: `curl http://127.0.0.1:18081/health-check` -> `"QUOTES Service Up"`
- MOEX container: `curl http://127.0.0.1:18082/health-check` -> `"MOEX Service Up"`
- `/tmp/tradebot-fia147-venv/bin/python -m pytest -rs` -> `192 passed in 2.24s`