### PR TITLE
FIA-46: Add Nox build test foundation

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,4 +20,4 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
       - name: Run tests
-        run: python -m pytest
+        run: python -m nox -s unit

--- a/README.md
+++ b/README.md
@@ -119,10 +119,19 @@ pip install -e ".[dev]"
 Run the test suite:
 
 ```bash
-pytest
+python -m nox -s unit
 ```
 
-Brokerage integration tests require separate credentials and configuration. Do not commit access tokens, private keys, account identifiers, or other secrets.
+For focused debugging, direct pytest remains useful:
+
+```bash
+python -m pytest tests/common/test_chain.py
+```
+
+See [`docs/testing.md`](docs/testing.md) for the test pyramid, Docker-backed
+test commands, and live brokerage safety gates. Brokerage integration tests
+require separate credentials and configuration. Do not commit access tokens,
+private keys, account identifiers, or other secrets.
 
 ## Contributing
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,94 @@
+# Testing
+
+TradeBot uses a test pyramid with explicit commands and explicit safety gates.
+Nox is the canonical interface for routine local validation and CI.
+
+Raw `python -m pytest` is still useful for tight local debugging, but shared
+project workflows should use Nox so local and CI behavior stay aligned.
+
+## Test Layers
+
+| Layer | Purpose | Default |
+| --- | --- | --- |
+| Unit | Tiny, isolated tests for one class, function, or module boundary | Safe |
+| Functional | In-process tests that exercise multiple classes or components | Safe |
+| Contract | Shared behavior tests for alternate implementations of the same port | Safe when service-free |
+| Docker smoke | Real container startup and health checks | Opt-in |
+| Docker integration | Service-to-service checks across real local processes or containers | Opt-in |
+| Live E2E | Paper-account E*Trade checks using real credentials | Opt-in, never default |
+
+Push tests as low in the pyramid as they can honestly go. Use Docker-backed
+tests for process, networking, readiness, or serialization boundaries. Use live
+paper-account tests only for risks that cannot be proven with fakes, simulators,
+or local containers.
+
+## Commands
+
+Install development dependencies:
+
+```bash
+python -m pip install -e ".[dev]"
+```
+
+Run the safe default suite:
+
+```bash
+python -m nox -s unit
+```
+
+Run the current in-process functional suite:
+
+```bash
+python -m nox -s functional
+```
+
+Run focused pytest commands through Nox:
+
+```bash
+python -m nox -s test -- tests/common/test_chain.py
+```
+
+Build the local Docker image after the Docker POC is present:
+
+```bash
+python -m nox -s docker_build
+```
+
+Run Docker-backed service smoke checks intentionally:
+
+```bash
+TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_smoke
+```
+
+The Docker integration session is reserved for the Docker Compose and reusable
+service lifecycle work in FIA-136, FIA-149, and FIA-152:
+
+```bash
+TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_integration
+```
+
+The live paper-account E*Trade session is reserved for FIA-153 and must remain
+separately gated:
+
+```bash
+TRADEBOT_RUN_LIVE_E2E_TESTS=1 python -m nox -s live_e2e
+```
+
+## Safety Gates
+
+Tests marked `service`, `docker`, or `integration` must not run as part of the
+ordinary unit workflow. Service/container tests require:
+
+```bash
+TRADEBOT_RUN_SERVICE_TESTS=1
+```
+
+Live E*Trade paper-account tests require a separate gate:
+
+```bash
+TRADEBOT_RUN_LIVE_E2E_TESTS=1
+```
+
+Do not commit brokerage credentials, access tokens, private keys, account
+identifiers, or generated credential files. Test failures should report which
+configuration is missing without printing secret values.

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+import nox
+
+
+nox.options.sessions = ["unit"]
+nox.options.default_venv_backend = "venv"
+
+PYTHON = os.environ.get("TRADEBOT_NOX_PYTHON", "3.14")
+SERVICE_TEST_ENV_VAR = "TRADEBOT_RUN_SERVICE_TESTS"
+LIVE_E2E_TEST_ENV_VAR = "TRADEBOT_RUN_LIVE_E2E_TESTS"
+DOCKER_IMAGE = os.environ.get("TRADEBOT_DOCKER_IMAGE", "tradebot:local")
+REPO_ROOT = Path(__file__).parent
+SAFE_PYTEST_MARKER_EXPR = "not service and not docker and not integration and not live_e2e"
+
+
+@dataclass(frozen=True)
+class DockerService:
+    name: str
+    module: str
+    container_port: int
+    host_port: int
+
+
+DOCKER_SMOKE_SERVICES = [
+    DockerService(
+        name="orders",
+        module="fianchetto_tradebot.server.orders.serving.orders_rest_service",
+        container_port=8080,
+        host_port=18080,
+    ),
+    DockerService(
+        name="quotes",
+        module="fianchetto_tradebot.server.quotes.serving.quotes_rest_service",
+        container_port=8081,
+        host_port=18081,
+    ),
+    DockerService(
+        name="moex",
+        module="fianchetto_tradebot.server.moex.serving.moex_rest_service",
+        container_port=8082,
+        host_port=18082,
+    ),
+]
+
+
+def _install_project(session: nox.Session) -> None:
+    session.install("-e", ".[dev]")
+
+
+def _run_pytest(session: nox.Session, *args: str) -> None:
+    session.run("python", "-m", "pytest", *args)
+
+
+def _require_env_gate(session: nox.Session, env_var: str, purpose: str) -> None:
+    if os.getenv(env_var) != "1":
+        session.skip(f"set {env_var}=1 to run {purpose}")
+
+
+def _require_docker_available(session: nox.Session) -> None:
+    if shutil.which("docker") is None:
+        session.error("docker is required for this session but was not found on PATH")
+
+
+def _require_dockerfile(session: nox.Session) -> None:
+    if not (REPO_ROOT / "Dockerfile").exists():
+        session.error("Dockerfile is required for this session; land FIA-133 before running it")
+
+
+def _docker_build(session: nox.Session) -> None:
+    _require_docker_available(session)
+    _require_dockerfile(session)
+    session.run(
+        "docker",
+        "build",
+        "--build-arg",
+        "PYTHON_VERSION=3.14",
+        "-t",
+        DOCKER_IMAGE,
+        ".",
+        external=True,
+    )
+
+
+def _run_docker_command(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["docker", *args],
+        check=True,
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def _wait_for_health(service: DockerService, timeout_seconds: int = 30) -> None:
+    health_url = f"http://127.0.0.1:{service.host_port}/health-check"
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(health_url, timeout=2) as response:
+                if response.status == 200:
+                    return
+        except (urllib.error.URLError, TimeoutError) as exc:
+            last_error = exc
+        time.sleep(1)
+
+    raise RuntimeError(f"{service.name} did not become healthy at {health_url}: {last_error}")
+
+
+def _container_name(service: DockerService) -> str:
+    return f"tradebot-nox-smoke-{service.name}"
+
+
+def _start_smoke_service(service: DockerService) -> None:
+    _run_docker_command(
+        "run",
+        "-d",
+        "--rm",
+        "--name",
+        _container_name(service),
+        "-e",
+        "FIANCHETTO_TRADEBOT_STATE_DIR=/app/deploy/docker/demo-state",
+        "-e",
+        f"TRADEBOT_HEALTHCHECK_PORT={service.container_port}",
+        "-p",
+        f"127.0.0.1:{service.host_port}:{service.container_port}",
+        DOCKER_IMAGE,
+        "python",
+        "-m",
+        service.module,
+    )
+
+
+def _stop_smoke_service(service: DockerService) -> None:
+    subprocess.run(
+        ["docker", "rm", "-f", _container_name(service)],
+        cwd=REPO_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+
+
+@nox.session(python=PYTHON, venv_backend="venv", download_python="never")
+def unit(session: nox.Session) -> None:
+    """Run the safe service-free test suite."""
+    _install_project(session)
+    _run_pytest(session, "-m", SAFE_PYTEST_MARKER_EXPR, "tests")
+
+
+@nox.session(python=PYTHON, venv_backend="venv", download_python="never")
+def functional(session: nox.Session) -> None:
+    """Run in-process tests until FIA-151 splits functional markers explicitly."""
+    _install_project(session)
+    session.log("Functional tests are not separately classified yet; running the safe suite.")
+    _run_pytest(session, "-m", SAFE_PYTEST_MARKER_EXPR, "tests")
+
+
+@nox.session(python=PYTHON, venv_backend="venv", download_python="never")
+def test(session: nox.Session) -> None:
+    """Run pytest with optional passthrough args, e.g. nox -s test -- tests/common/test_chain.py."""
+    _install_project(session)
+    _run_pytest(session, *(session.posargs or ["tests"]))
+
+
+@nox.session(python=False)
+def docker_build(session: nox.Session) -> None:
+    """Build the local TradeBot Docker image."""
+    _docker_build(session)
+
+
+@nox.session(python=False)
+def docker_smoke(session: nox.Session) -> None:
+    """Build the image and verify representative service health checks."""
+    _require_env_gate(session, SERVICE_TEST_ENV_VAR, "Docker-backed service smoke tests")
+    _docker_build(session)
+
+    started_services: list[DockerService] = []
+    try:
+        for service in DOCKER_SMOKE_SERVICES:
+            _start_smoke_service(service)
+            started_services.append(service)
+            _wait_for_health(service)
+            session.log("%s service is healthy on port %s", service.name, service.host_port)
+    finally:
+        for service in reversed(started_services):
+            _stop_smoke_service(service)
+
+
+@nox.session(python=False)
+def docker_integration(session: nox.Session) -> None:
+    """Reserved for Docker Compose/service-boundary tests."""
+    _require_env_gate(session, SERVICE_TEST_ENV_VAR, "Docker-backed integration tests")
+    session.error("Docker integration orchestration belongs to FIA-136/FIA-149/FIA-152")
+
+
+@nox.session(python=False)
+def live_e2e(session: nox.Session) -> None:
+    """Reserved for paper-account brokerage E2E tests."""
+    _require_env_gate(session, LIVE_E2E_TEST_ENV_VAR, "live paper-account E*Trade E2E tests")
+    session.error("live E*Trade paper-account tests belong to FIA-153")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "build>=1.2,<2.0",
+    "nox>=2026.7,<2027.0",
     "pyproject_hooks>=1.2,<2.0",
     "pytest>=8.3,<9.0",
 ]
@@ -78,6 +79,9 @@ where = ["src"]
 [tool.pytest.ini_options]
 pythonpath = ["src", "tests"]
 markers = [
+    "contract: verifies that two implementations satisfy the same behavioral contract",
     "service: requires one or more local service processes to be running",
     "docker: requires Docker or Docker Compose",
+    "integration: crosses a real process, container, or external-service boundary",
+    "live_e2e: requires live paper-account brokerage credentials and external brokerage access",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
 build>=1.2,<2.0
+nox>=2026.7,<2027.0
 pyproject_hooks>=1.2,<2.0
 pytest>=8.3,<9.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,15 +4,28 @@ import pytest
 
 
 SERVICE_TEST_ENV_VAR = "TRADEBOT_RUN_SERVICE_TESTS"
+LIVE_E2E_TEST_ENV_VAR = "TRADEBOT_RUN_LIVE_E2E_TESTS"
+SERVICE_GATED_MARKERS = ("service", "docker", "integration")
+LIVE_E2E_GATED_MARKERS = ("live_e2e",)
 
 
 def pytest_collection_modifyitems(config, items):
-    if os.getenv(SERVICE_TEST_ENV_VAR) == "1":
-        return
-
     skip_service_test = pytest.mark.skip(
         reason=f"set {SERVICE_TEST_ENV_VAR}=1 to run service or Docker tests"
     )
+    skip_live_e2e_test = pytest.mark.skip(
+        reason=f"set {LIVE_E2E_TEST_ENV_VAR}=1 to run live paper-account E2E tests"
+    )
+
+    service_tests_enabled = os.getenv(SERVICE_TEST_ENV_VAR) == "1"
+    live_e2e_tests_enabled = os.getenv(LIVE_E2E_TEST_ENV_VAR) == "1"
+
     for item in items:
-        if item.get_closest_marker("service") or item.get_closest_marker("docker"):
+        if not live_e2e_tests_enabled and any(
+            item.get_closest_marker(marker) for marker in LIVE_E2E_GATED_MARKERS
+        ):
+            item.add_marker(skip_live_e2e_test)
+        if not service_tests_enabled and any(
+            item.get_closest_marker(marker) for marker in SERVICE_GATED_MARKERS
+        ):
             item.add_marker(skip_service_test)


### PR DESCRIPTION
## Summary

- Add Nox as the canonical build/test command layer for TradeBot.
- Add safe unit, functional, and focused pytest sessions.
- Add Docker build/smoke and live E*Trade E2E entrypoints behind explicit safety gates.
- Update CI to install through package metadata and run the Nox unit session.
- Document the test pyramid and the intended Nox commands in `docs/testing.md`.

## Scope

This is the first chunk of FIA-46. It establishes the command interface and safety gates without trying to finish the whole testing pyramid.

Follow-up scope remains intentionally split out:

- FIA-151: full pytest marker/layout conventions.
- FIA-152: reusable Docker service lifecycle harness.
- FIA-153: guarded live E*Trade paper-account E2E framework.

## Verification

- `python3 -m py_compile noxfile.py tests/conftest.py`
- `python3 pyproject parse check via tomllib`
- `/tmp/tradebot-fia147-venv/bin/python -m pytest -q tests/common/test_chain.py`: 9 passed
- `/tmp/tradebot-fia147-venv/bin/python -m pytest -q`: 192 passed
- `/tmp/tradebot-nox-runner/bin/python -m nox --list`
- `/tmp/tradebot-nox-runner/bin/python -m nox -s docker_integration`: skipped without `TRADEBOT_RUN_SERVICE_TESTS=1`
- `/tmp/tradebot-nox-runner/bin/python -m nox -s live_e2e`: skipped without `TRADEBOT_RUN_LIVE_E2E_TESTS=1`
- `TRADEBOT_RUN_SERVICE_TESTS=1 /tmp/tradebot-nox-runner/bin/python -m nox -s docker_build`: expected failure because Dockerfile is pending from FIA-133
- `/tmp/tradebot-nox314-runner/bin/python -m nox -s unit`: 192 passed on Python 3.14.6
- GitHub Actions `test`: passed

## Notes

- Local Python 3.14 is now available and the Nox unit session has been verified locally.
- Nox may print `uv binary not found` during interpreter discovery, but the configured sessions use `venv`; no `uv` dependency is required.
- PR #64 (`FIA-67: Add contributor onboarding docs`) is stacked on this branch because those docs reference the Nox workflow introduced here. Merge this PR first, then retarget or merge #64.
