### PR TITLE
FIA-67: Add contributor onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,12 @@ client = Client(Brokerage.ETRADE)
 accounts = client.get_accounts()
 ```
 
-For local environment setup and brokerage configuration, see:
+For local development setup and related guides, see:
 
 - [`dev_get_started_guides/set_up_local_env.MD`](dev_get_started_guides/set_up_local_env.MD)
-- [`dev_get_started_guides/exchange_setup.MD`](dev_get_started_guides/exchange_setup.MD)
 - [`docs/serialization.md`](docs/serialization.md)
+- [`dev_get_started_guides/exchange_setup.MD`](dev_get_started_guides/exchange_setup.MD) only if your
+  work explicitly needs real or sandbox brokerage credentials.
 
 > The client API is evolving. Consult the source and tests for the current constructor and supported operations.
 
@@ -109,11 +110,12 @@ For local environment setup and brokerage configuration, see:
 Clone the repository and install the package with development dependencies:
 
 ```bash
-git clone https://github.com/fianchetto-labs/tradebot.git
+git clone git@github.com:fianchetto-labs/tradebot.git
 cd tradebot
-python -m venv .venv
+python3.14 -m venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev]"
 ```
 
 Run the test suite:
@@ -122,10 +124,10 @@ Run the test suite:
 python -m nox -s unit
 ```
 
-For focused debugging, direct pytest remains useful:
+For focused debugging, route pytest through Nox:
 
 ```bash
-python -m pytest tests/common/test_chain.py
+python -m nox -s test -- tests/common/test_chain.py
 ```
 
 See [`docs/testing.md`](docs/testing.md) for the test pyramid, Docker-backed
@@ -143,6 +145,11 @@ Contributions are welcome. Useful areas include:
 - Strategy research components
 - Test coverage and brokerage simulators
 - Documentation and reproducible local development
+
+New contributors can start with the
+[`New Contributor Quickstart`](docs/new-contributor-quickstart.md), which
+covers account access, cloning, local setup, starter tickets, and first PR
+conventions.
 
 Before opening a pull request, add or update tests for behavioral changes and clearly identify any brokerage-specific assumptions.
 

--- a/dev_get_started_guides/exchange_setup.MD
+++ b/dev_get_started_guides/exchange_setup.MD
@@ -1,40 +1,57 @@
-# 📈 TradeBot: Getting Started with an Exchange
+# TradeBot Brokerage Setup
 
-Welcome to the TradeBot ecosystem! This guide will help you connect your first exchange and execute your first trade.
+Most contributors do not need this guide on day one. Use it only when your
+ticket explicitly needs real or sandbox brokerage credentials.
 
-TradeBot currently supports:
+For ordinary documentation, model, serialization, service-adapter, simulator,
+and unit-test work, stay credentials-free and use the normal local setup:
 
-- 🏦 **E*TRADE** – [API Docs](https://apisb.etrade.com/docs/api/overview.html)
-- 🏦 **Charles Schwab** – [API Docs](https://developer.schwab.com/products/trader-api--individual)
-- 🏦 **Interactive Brokers (IBKR)** – [API Docs](https://interactivebrokers.github.io/)
+- [New Contributor Quickstart](../docs/new-contributor-quickstart.md)
+- [Local development setup](set_up_local_env.MD)
+- [Testing guide](../docs/testing.md)
+- [E*Trade simulator contract](../docs/etrade-simulator-contract.md)
 
----
+## Supported Brokerages
 
-## 🔐 1. Authentication Overview
+Brokerage support is evolving and is not uniform across integrations.
 
-Each exchange requires an API key and secret to authenticate. These are stored in a `config.ini` file that you'll need to create (per exchange).
+| Brokerage | Status | Credentialed validation |
+| --- | --- | --- |
+| E*Trade | Primary current integration | Sandbox/live OAuth credentials |
+| Schwab | In development | Do not assume full workflow support |
+| Interactive Brokers (IBKR) | Planned | Paper trading support is roadmap work |
 
-### How to Set Up
+Use simulator-backed tests for process, networking, and serialization checks
+whenever possible. Use sandbox or live brokerage validation only for risks that
+cannot be proven with unit tests, fakes, or the simulator.
 
-1. Navigate to the appropriate brokerage directory:
-   - `src/fianchetto_tradebot/server/common/brokerage/etrade/`
-   - `src/fianchetto_tradebot/server/common/brokerage/ibkr/`
-   - `src/fianchetto_tradebot/server/common/brokerage/schwab/`
+## Safety Rules
 
-2. Copy the example config file:
+- Never commit `config.ini`, credential caches, tokens, private keys, account
+  identifiers, screenshots containing account data, or generated credential
+  files.
+- Prefer sandbox or paper accounts for validation.
+- Keep live order-placement work out of ordinary local test runs.
+- Use the explicit test gates documented in [Testing](../docs/testing.md).
+- If a command would place, cancel, or modify a real order, stop and confirm the
+  intended account, environment, and ticket scope first.
+
+## E*Trade Config
+
+The E*Trade connector reads configuration from:
+
+```text
+src/fianchetto_tradebot/server/common/brokerage/etrade/config.ini
+```
+
+Create it from the example:
 
 ```bash
+cd src/fianchetto_tradebot/server/common/brokerage/etrade
 cp config.example.ini config.ini
 ```
 
-3. Open the new `config.ini` and fill in your API keys.  
-   The `BASE_URL` values are already set and do **not** need to be changed.
-
----
-
-## 🧾 Config File Format
-
-Each exchange’s `config.ini` should follow this format:
+Then fill in the sandbox and/or production values provided by E*Trade:
 
 ```ini
 [DEFAULT]
@@ -50,65 +67,54 @@ PROD_API_KEY=<PROD_API_KEY>
 PROD_API_SECRET=<PROD_API_SECRET>
 ```
 
-> 🔒 These `config.ini` files are already included in `.gitignore` — **do not commit them**.
+`config.ini` files are ignored by Git. Keep them local.
 
----
+## Credential Cache
 
-## 🧪 2. Sandbox vs. Live
+After OAuth succeeds, E*Trade connection state is cached under:
 
-| Exchange     | Sandbox Support | Notes                                             |
-|--------------|-----------------|---------------------------------------------------|
-| E*TRADE      | ✅               | Fully-featured sandbox for testing                |
-| Schwab       | ❌               | Use small trades or test data only               |
-| IBKR         | ✅               | Paper Trading supported via TWS or Gateway       |
-
-
-
-```python
-from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import ETradeConnector
-
-connector: ETradeConnector = ETradeConnector()
+```text
+~/.fianchetto_tradebot/etrade/
 ```
 
-> Enable sandbox mode in the client initialization:
-At E*Trade login, at runtime, select `1` for the `Sandbox` option, `2` for `Live`. 
-```
+The current credential cache stores OAuth-shaped values plus a `base_url`.
+Simulator-backed deployments can use fake but well-formed credential values;
+live brokerage validation must use real credentials.
+
+The E*Trade base URL precedence is:
+
+1. `TRADEBOT_ETRADE_API_BASE_URL`
+2. `base_url` in the credential cache
+3. legacy standalone `base_url.json`
+4. interactive OAuth establishment
+
+See [E*Trade simulator contract](../docs/etrade-simulator-contract.md) for the
+simulator-backed credential shape and fake-value conventions.
+
+## Manual E*Trade OAuth
+
+When the E*Trade connector cannot load a valid cached connection, it starts an
+interactive OAuth flow. At the prompt, choose sandbox unless your ticket
+explicitly requires live validation:
+
+```text
 1) Sandbox Consumer Key
 2) Live Consumer Key
 3) Exit
 Please select Consumer Key Type: 1
 ```
 
----
+The connector opens a browser, asks you to authorize the app, and prompts for
+the verification code.
 
-## 🚀 3. First Call: Verify Connection
+## First Validation
 
-Try pulling account info to ensure your credentials and config are working:
+For a new contributor, the first validation should still be credentials-free:
 
-```python
-from fianchetto_tradebot.client import TradeBotClient
-from fianchetto_tradebot.models import GetAccountRequest
-
-req = GetAccountRequest(brokerage="etrade", account_id="your_account_id")
-response = TradeBotClient().get_account(req)
-print(response)
+```bash
+python -m nox -s unit
 ```
 
-You should see your account summary or positions if everything is correctly configured.
-
----
-
-## 🛡️ 4. Security Tips
-
-- Never commit `config.ini` files.
-- Use encrypted secrets for production environments.
-- Rotate keys and secrets regularly.
-- Restrict key permissions during testing (read-only where possible).
-
----
-
-## 🆘 Need Help?
-
-- Open an issue on [GitHub](https://github.com/Fianchetto-Labs/TradeBot/issues)
-- Or contact the maintainer:  
-  📧 **aleks@fianchettolabs.com**
+If your ticket needs a credentialed E*Trade check, define the smallest safe
+manual validation with Aleks before running it. Prefer read-only account or
+quote calls before any order workflow.

--- a/dev_get_started_guides/publishing_and_tagging.MD
+++ b/dev_get_started_guides/publishing_and_tagging.MD
@@ -22,7 +22,7 @@ We use three-part version numbers: `MAJOR.MINOR.PATCH` (e.g. `0.1.15`):
 
 ```bash
 git checkout main
-git pull origin main
+git pull --ff-only origin main
 ```
 
 ---
@@ -63,7 +63,7 @@ Ensure the version follows [semantic versioning](https://semver.org/) and is new
 Run all tests to ensure the package is in a good state:
 
 ```bash
-pytest
+python -m nox -s unit
 ```
 
 ---
@@ -105,7 +105,7 @@ Successfully built fianchetto_tradebot-0.1.15.tar.gz and fianchetto_tradebot-0.1
 Install `twine` if needed:
 
 ```bash
-pip install twine
+python -m pip install twine
 ```
 
 Upload the built distributions:

--- a/dev_get_started_guides/set_up_local_env.MD
+++ b/dev_get_started_guides/set_up_local_env.MD
@@ -1,108 +1,136 @@
-# 🧠 TradeBot Developer Onboarding Guide
+# TradeBot Local Development Setup
 
-Welcome to **TradeBot**, the algorithmic trading system by [Fianchetto Labs](https://github.com/Fianchetto-Labs/TradeBot). This guide will help new developers set up their environment and verify their installation to contribute effectively.
+This guide is the detailed local setup path for TradeBot contributors. If you
+are brand new to the project, start with the friendlier
+[New Contributor Quickstart](../docs/new-contributor-quickstart.md), then come
+back here when you want more detail.
 
----
+You do not need brokerage credentials to run the normal development setup or
+the safe test suite.
 
-## 🚀 Getting Started
+## 1. Get Access
 
-### 1. Clone the Repository
+Ask Aleks for GitHub access that lets you clone the repository, push feature
+branches, and open pull requests against `fianchetto-labs/tradebot`.
 
-Use SSH to clone the repository:
+You will also want access to the Fianchetto Labs Linear workspace so you can
+claim tickets and link PRs to issues.
 
-```bash
-git clone git@github.com:Fianchetto-Labs/TradeBot.git
-cd TradeBot
-```
+Useful setup links:
 
-> 🔐 **Access Required:**
-> If you don't yet have SSH access to the repo, please email the maintainer at:
-> 📧 **aleks@fianchettolabs.com**
+- [GitHub SSH setup](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
+- [Testing your GitHub SSH connection](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection)
+- [Fianchetto Labs Linear issues](https://linear.app/fianchetto-labs/view/all-issues-1d578a3e4473)
 
----
+## 2. Clone The Repository
 
-## 🐍 Python Environment
-
-- **Recommended Python version:** `>=3.7`
-- Use `virtualenv` (preferred), `conda`, or `pyenv` to manage Python versions and environments.
-
-Create a virtual environment:
+Use SSH:
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate  # or .venv\Scripts\activate on Windows
-pip install --upgrade pip
+git clone git@github.com:fianchetto-labs/tradebot.git
+cd tradebot
 ```
 
-Install project dependencies (once defined in `requirements.txt` or via `pyproject.toml`):
+Confirm you are in the Git root:
 
 ```bash
-pip install -r requirements.txt  # or use poetry/pip-tools as appropriate
+git status --short --branch
 ```
 
----
+If cloning fails with `Permission denied (publickey)`, confirm that your SSH key
+is loaded, added to GitHub, and that you accepted the repository invite.
 
-## 🛠 Recommended IDE: PyCharm
+## 3. Install Python
 
-We suggest using **PyCharm** for the best experience. Once the project is opened:
+TradeBot targets Python 3.14.
 
-1. Mark the following as **Sources Root**:
-    - `src/`
-2. Mark the following as **Tests Root**:
-    - `tests/`
+Check your local version:
 
-You can do this by right-clicking the folder in PyCharm's file browser → *Mark Directory As* → *Sources Root* or *Tests Root*.
+```bash
+python3.14 --version
+```
 
+If that command fails, install Python 3.14 with your normal toolchain. On macOS,
+reasonable options include Homebrew, pyenv, or asdf.
 
-### 🧪 Running Tests in PyCharm
+## 4. Create A Virtual Environment
 
-In addition to the command line, you can run tests directly in **PyCharm**:
+```bash
+python3.14 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev]"
+```
 
-#### ▶️ Option 1: Run Tests via Right-Click
-1. Navigate to the `tests/` directory or a specific test file.
-2. Right-click and choose **Run 'pytest in ...'**.
-3. PyCharm will automatically use the configured interpreter and show results in the test runner pane.
+The editable install with `.[dev]` is the normal contributor setup. It installs
+the package plus development tools such as pytest and Nox.
 
-#### 🐞 Option 2: Debug Tests
-1. Right-click a test file or individual test function.
-2. Choose **Debug 'pytest for ...'**.
-3. This launches the debugger and allows you to set breakpoints, inspect variables, and step through code.
+## 5. Run Tests
 
-> 💡 Make sure your `src/` and `tests/` folders are properly marked as source roots to ensure correct module resolution.
+Run the safe default suite:
 
----
+```bash
+python -m nox -s unit
+```
 
-## ✅ Verifying the Setup
+This should pass without brokerage credentials. Docker-backed and live
+brokerage tests are intentionally gated and are not part of the ordinary unit
+workflow.
 
-To confirm your environment is set up correctly:
+For focused debugging, route pytest through Nox:
 
-1. Add the `src/` and `tests/` directories to your `PYTHONPATH`. In bash:
+```bash
+python -m nox -s test -- tests/common/test_chain.py
+```
 
-    ```bash
-    export PYTHONPATH=$PYTHONPATH:$(pwd)/src:$(pwd)/tests
-    ```
+If you intentionally need Docker or live brokerage validation, read the
+[Testing guide](../docs/testing.md) first. Those commands require explicit
+environment variables so they do not run by accident.
 
-2. Run the tests:
+## 6. Optional PyCharm Setup
 
-    ```bash
-    pytest
-    ```
+PyCharm works well for this project.
 
-    You should see the test suite run and pass successfully.
+After opening the repository:
 
----
+1. Configure the interpreter as `.venv/bin/python`.
+2. Mark `src/` as a Sources Root.
+3. Mark `tests/` as a Tests Root.
 
-## 🧪 Continuous Integration (CI)
+The repo also configures pytest's Python path in `pyproject.toml`, so command
+line test runs should not require manually exporting `PYTHONPATH`.
 
-This project uses **GitHub Actions** to automatically test changes when code is pushed or a pull request is opened.
+## 7. First Contribution Workflow
 
-### 🔄 How it Works
+1. Pick a Linear ticket.
+2. Comment that you are taking it, assign yourself if you have permission, and
+   move it to In Progress.
+3. Pull the latest `main`.
+4. Create a branch with the ticket number:
 
-Every time you:
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b githubusername/fia-124-short-slug
+```
 
-- Push to a branch
-- Open a pull request
+Use the Linear key in the PR title:
 
-...GitHub Actions runs the test suite to ensure everything still works.
+```text
+FIA-124: Fix first connection docs
+```
 
-You can always check the status of the CI pipeline at the top of your pull request or on the repository’s **Actions** tab.
+Before opening the PR, run the smallest meaningful validation. For code changes,
+that usually starts with:
+
+```bash
+python -m nox -s unit
+```
+
+For docs-only changes, a careful read plus `git diff --check` is usually enough.
+
+## 8. CI
+
+GitHub Actions runs the project checks when you push a branch or open a pull
+request. Check the PR page for status and link any surprising failure back to
+the Linear ticket or PR discussion.

--- a/docs/etrade-simulator-contract.md
+++ b/docs/etrade-simulator-contract.md
@@ -141,7 +141,7 @@ Base URL precedence is explicit:
 Run the executable seed contract with:
 
 ```bash
-python -m pytest tests/common/api/etrade_simulator/test_etrade_simulator_contract.py
+python -m nox -s test -- tests/common/api/etrade_simulator/test_etrade_simulator_contract.py
 ```
 
 ## Service Test Safety
@@ -166,11 +166,11 @@ def test_simulator_backed_stack_smoke():
 The default test command remains safe:
 
 ```bash
-python -m pytest
+python -m nox -s unit
 ```
 
-Tests marked `service` or `docker` are skipped unless the caller deliberately
-sets:
+Tests marked `service` or `docker` are skipped or deselected unless the caller
+deliberately sets:
 
 ```bash
 TRADEBOT_RUN_SERVICE_TESTS=1
@@ -180,7 +180,7 @@ Run Docker-backed service tests intentionally with:
 
 ```bash
 TRADEBOT_RUN_SERVICE_TESTS=1 docker compose up -d
-TRADEBOT_RUN_SERVICE_TESTS=1 python -m pytest -m docker tests
+TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s test -- -m docker tests
 ```
 
 This keeps simple unit-test invocations credentials-free and service-free while

--- a/docs/new-contributor-quickstart.md
+++ b/docs/new-contributor-quickstart.md
@@ -1,0 +1,169 @@
+# New Contributor Quickstart
+
+Welcome! TradeBot has a lot of surface area, but you do not need to understand
+all of it to make a useful first contribution. The goal for day one is simple:
+get access, clone the repo, run the safe tests, and pick a small ticket.
+
+## Access Checklist
+
+Ask Aleks for:
+
+- GitHub access that lets you clone `fianchetto-labs/tradebot`, push feature
+  branches, and open pull requests.
+- A Linear workspace invite for Fianchetto Labs.
+- Any project context for the ticket you want to start.
+
+You do not need brokerage credentials for ordinary development, documentation,
+unit tests, or simulator-backed work. Live or sandbox brokerage credentials are
+only needed for explicitly credentialed E*Trade validation.
+
+## GitHub Setup
+
+1. Create or use your GitHub account.
+2. Add an SSH key to GitHub:
+   [GitHub SSH setup](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
+3. Accept the repository invite.
+4. Confirm SSH works:
+
+```bash
+ssh -T git@github.com
+```
+
+GitHub should recognize your account. If it says `Permission denied
+(publickey)`, the SSH key is either missing from GitHub, not loaded into your
+agent, or the repository invite has not been accepted yet.
+
+Useful official docs:
+
+- [Adding a new SSH key to your GitHub account](https://docs.github.com/articles/adding-a-new-ssh-key-to-your-github-account)
+- [Testing your SSH connection](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection)
+- [Managing repository access](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-teams-and-people-with-access-to-your-repository)
+
+## Linear Setup
+
+Accept the Linear invite from your email, then open the Fianchetto Labs
+workspace:
+
+- [Fianchetto Labs Linear issues](https://linear.app/fianchetto-labs/view/all-issues-1d578a3e4473)
+
+Useful official docs:
+
+- [Linear invite members](https://linear.app/docs/invite-members)
+- [Linear members and roles](https://linear.app/docs/members-roles)
+
+## Clone The Repo
+
+```bash
+git clone git@github.com:fianchetto-labs/tradebot.git
+cd tradebot
+```
+
+If SSH is not ready yet, cloning will fail. Fix GitHub access first; it saves
+time later when pushing branches.
+
+## Local Python Setup
+
+TradeBot targets Python 3.14.
+
+Check that it is available:
+
+```bash
+python3.14 --version
+```
+
+If that command fails, install Python 3.14 with your normal toolchain. On macOS,
+Homebrew, pyenv, and asdf are all reasonable choices.
+
+```bash
+python3.14 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev]"
+```
+
+Run the safe test suite:
+
+```bash
+python -m nox -s unit
+```
+
+This should pass without brokerage credentials. Docker or live brokerage tests
+may be skipped or deselected unless you explicitly enable them.
+
+For a focused test while debugging:
+
+```bash
+python -m nox -s test -- tests/common/test_chain.py
+```
+
+Avoid running Docker, simulator, or live brokerage tests unless the ticket
+explicitly asks for them. Those are intentionally gated.
+
+## Good First Tickets
+
+These are useful places to start. Pick one, read the surrounding code/docs, and
+ask Aleks for any missing background before going deep. When you choose one,
+comment on the ticket, assign yourself if you have permission, and move it to In
+Progress.
+
+| Ticket | Why it is a good start |
+| --- | --- |
+| [FIA-124: Fix `First Call to Verify Connection` section in docs](https://linear.app/fianchetto-labs/issue/FIA-124/fix-first-call-to-verify-connection-section-in-docs) | Small docs fix that teaches the current client shape. |
+| [FIA-130: Add file for PyPI packaging and GitHub tagging for TradeBot-Quickstart](https://linear.app/fianchetto-labs/issue/FIA-130/add-file-for-pypi-packaging-and-github-tagging-for-tradebot-quickstart) | Documentation-heavy warmup with low production risk. |
+| [FIA-66: Add a ways-of-working file](https://linear.app/fianchetto-labs/issue/FIA-66/add-a-ways-of-working-file-that-explains-the-standards-and-norms-of) | Helps make future collaboration smoother. |
+| [FIA-150: Document simulator-backed deployment mode](https://linear.app/fianchetto-labs/issue/FIA-150/document-simulator-backed-deployment-mode) | Good if you want to learn the Docker/simulator direction without touching live brokerage credentials. |
+| [FIA-151: Add pytest markers and test layout conventions](https://linear.app/fianchetto-labs/issue/FIA-151/add-pytest-markers-and-test-layout-conventions-for-the-test-pyramid) | Good if you like test infrastructure and clean project conventions. |
+
+## Project Docs To Skim
+
+Start with these:
+
+- [README](../README.md)
+- [Testing guide](testing.md)
+- [Developer local setup](../dev_get_started_guides/set_up_local_env.MD)
+
+Then read whichever one matches your ticket:
+
+- [Serialization conventions](serialization.md)
+- [Service ports and adapter boundaries](service-ports.md)
+- [E*Trade simulator contract](etrade-simulator-contract.md)
+- [Publishing and tagging](../dev_get_started_guides/publishing_and_tagging.MD)
+- [Brokerage setup](../dev_get_started_guides/exchange_setup.MD) only if your
+  ticket explicitly needs real or sandbox brokerage credentials.
+
+## Branch And PR Convention
+
+Start from the latest `main`, then create a branch with the Linear ticket
+number:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b githubusername/fia-124-short-slug
+```
+
+Use the ticket number in the PR title so GitHub and Linear link it:
+
+```text
+FIA-124: Fix first connection docs
+```
+
+Before opening the PR, run the smallest meaningful validation. For docs-only
+changes, that may just be a careful reread. For code changes, run at least:
+
+```bash
+python -m nox -s unit
+```
+
+## First-Day Goal
+
+The best first milestone is intentionally small:
+
+1. Accept GitHub and Linear invites.
+2. Clone the repo.
+3. Install the dev environment.
+4. Run `python -m nox -s unit`.
+5. Pick one starter ticket and open a draft PR.
+
+That is enough. The rest of the system will make more sense after one small
+change has gone through the loop.

--- a/docs/service-ports.md
+++ b/docs/service-ports.md
@@ -47,7 +47,7 @@ HTTP adapters should construct URLs using the route path values required by the 
 Run the adapter contract simulation with:
 
 ```bash
-python -m pytest tests/common/service/test_service_adapter_contracts.py
+python -m nox -s test -- tests/common/service/test_service_adapter_contracts.py
 ```
 
 This starts fake in-process FastAPI order and quote services and drives them through the same port methods as local adapters. It is the fastest demo that local and network mode still agree without requiring brokerage credentials.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,8 +3,9 @@
 TradeBot uses a test pyramid with explicit commands and explicit safety gates.
 Nox is the canonical interface for routine local validation and CI.
 
-Raw `python -m pytest` is still useful for tight local debugging, but shared
-project workflows should use Nox so local and CI behavior stay aligned.
+Raw `python -m pytest` can still be useful as a tight local debugging escape
+hatch, but shared project workflows should use Nox so local and CI behavior
+stay aligned.
 
 ## Test Layers
 


### PR DESCRIPTION
## Summary

Adds a friendly new contributor quickstart and updates the existing developer docs so onboarding guidance is consistent across the repo.

- Add `docs/new-contributor-quickstart.md` with account setup, clone/setup commands, starter tickets, and first PR flow.
- Refresh the legacy local setup and brokerage setup guides around Python 3.14, editable dev installs, Nox, and credential safety.
- Align README, testing-adjacent docs, and publishing docs with the current Nox-based contributor workflow.

## Ticket

[FIA-67: Add a developer onboarding document](https://linear.app/fianchetto-labs/issue/FIA-67/add-a-developer-onboarding-document)

## Verification

- `git diff --check origin/main...HEAD`
- stale-pattern search for old clone URL, stale Python guidance, direct `pytest` as canonical workflow, stale client snippets, and `IKBR`
- local doc link target existence check

## Notes

PR #63 has merged, so this onboarding PR is now rebased and targeted directly at `main`.
