### PR TITLE
FIA-154: Improve Docker smoke dogfooding

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http.client
 import os
 import shutil
 import subprocess
@@ -112,7 +113,12 @@ def _wait_for_health(service: DockerService, timeout_seconds: int = 30) -> None:
             with urllib.request.urlopen(health_url, timeout=2) as response:
                 if response.status == 200:
                     return
-        except (urllib.error.URLError, TimeoutError) as exc:
+        except (
+            ConnectionResetError,
+            http.client.RemoteDisconnected,
+            urllib.error.URLError,
+            TimeoutError,
+        ) as exc:
             last_error = exc
         time.sleep(1)
 


### PR DESCRIPTION
## Summary
- Treat transient connection resets and remote disconnects as retryable Docker smoke readiness failures.
- Keep Docker smoke containers running for 30 minutes after health checks pass so developers can inspect them in Docker Desktop, curl health endpoints, and review logs.
- Label each smoke run with a run id and schedule TTL cleanup that only removes containers from that run.
- Document the smoke container lifecycle and early cleanup command.

## Linear
- [FIA-154](https://linear.app/fianchetto-labs/issue/FIA-154/make-docker-smoke-health-checks-tolerate-startup-connection-resets)

## Verification
- `python3.14 -m py_compile noxfile.py`
- `git diff --check`
- `TRADEBOT_RUN_SERVICE_TESTS=1 .venv/bin/python -m nox -s docker_smoke`
- Confirmed smoke containers remain running and healthy after Nox exits:
  - `tradebot-nox-smoke-orders` on `127.0.0.1:18080`
  - `tradebot-nox-smoke-quotes` on `127.0.0.1:18081`
  - `tradebot-nox-smoke-moex` on `127.0.0.1:18082`
- Confirmed health checks respond on all three ports.

## Notes
- Smoke containers bind only to localhost.
- The TTL is 30 minutes. Re-running `docker_smoke` removes prior smoke containers before starting fresh ones.
- The scheduled cleanup is scoped by a per-run Docker label so an older cleanup timer cannot remove a newer smoke run.