### PR TITLE
FIA-154: Keep Docker smoke containers available briefly

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -61,6 +61,27 @@ Run Docker-backed service smoke checks intentionally:
 TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_smoke
 ```
 
+This starts the orders, quotes, and MOEX smoke containers after building the
+local image. After their health checks pass, the containers remain available
+for 30 minutes so you can inspect them in Docker Desktop, curl their health
+checks, or review logs. The smoke harness schedules automatic cleanup at the
+end of that window and also removes any previous smoke containers before
+starting a fresh run.
+
+The smoke containers bind only to localhost:
+
+```bash
+curl http://127.0.0.1:18080/health-check
+curl http://127.0.0.1:18081/health-check
+curl http://127.0.0.1:18082/health-check
+```
+
+To clean them up early:
+
+```bash
+docker rm -f tradebot-nox-smoke-orders tradebot-nox-smoke-quotes tradebot-nox-smoke-moex
+```
+
 The Docker integration session is reserved for the Docker Compose and reusable
 service lifecycle work in FIA-136, FIA-149, and FIA-152:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,9 +4,11 @@ import http.client
 import os
 import shutil
 import subprocess
+import sys
 import time
 import urllib.error
 import urllib.request
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -20,6 +22,7 @@ PYTHON = os.environ.get("TRADEBOT_NOX_PYTHON", "3.14")
 SERVICE_TEST_ENV_VAR = "TRADEBOT_RUN_SERVICE_TESTS"
 LIVE_E2E_TEST_ENV_VAR = "TRADEBOT_RUN_LIVE_E2E_TESTS"
 DOCKER_IMAGE = os.environ.get("TRADEBOT_DOCKER_IMAGE", "tradebot:local")
+SMOKE_CONTAINER_TTL_SECONDS = 30 * 60
 REPO_ROOT = Path(__file__).parent
 SAFE_PYTEST_MARKER_EXPR = "not service and not docker and not integration and not live_e2e"
 
@@ -129,13 +132,18 @@ def _container_name(service: DockerService) -> str:
     return f"tradebot-nox-smoke-{service.name}"
 
 
-def _start_smoke_service(service: DockerService) -> None:
+def _start_smoke_service(service: DockerService, run_id: str) -> None:
     _run_docker_command(
         "run",
         "-d",
-        "--rm",
         "--name",
         _container_name(service),
+        "--label",
+        "fianchetto.tradebot.kind=nox-smoke",
+        "--label",
+        f"fianchetto.tradebot.run-id={run_id}",
+        "--label",
+        f"fianchetto.tradebot.ttl-seconds={SMOKE_CONTAINER_TTL_SECONDS}",
         "-e",
         "FIANCHETTO_TRADEBOT_STATE_DIR=/app/deploy/docker/demo-state",
         "-e",
@@ -146,6 +154,26 @@ def _start_smoke_service(service: DockerService) -> None:
         "python",
         "-m",
         service.module,
+    )
+
+
+def _schedule_smoke_service_cleanup(run_id: str) -> None:
+    cleanup_script = (
+        "import subprocess, sys, time; "
+        "time.sleep(int(sys.argv[1])); "
+        "containers = subprocess.run("
+        "['docker', 'ps', '-a', '--filter', f'label=fianchetto.tradebot.run-id={sys.argv[2]}', "
+        "'--format', '{{.ID}}'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, "
+        "text=True, check=False).stdout.splitlines(); "
+        "containers and subprocess.run(['docker', 'rm', '-f', *containers], "
+        "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)"
+    )
+    subprocess.Popen(
+        [sys.executable, "-c", cleanup_script, str(SMOKE_CONTAINER_TTL_SECONDS), run_id],
+        cwd=REPO_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
     )
 
 
@@ -193,16 +221,24 @@ def docker_smoke(session: nox.Session) -> None:
     _require_env_gate(session, SERVICE_TEST_ENV_VAR, "Docker-backed service smoke tests")
     _docker_build(session)
 
+    for service in DOCKER_SMOKE_SERVICES:
+        _stop_smoke_service(service)
+
+    run_id = uuid.uuid4().hex
     started_services: list[DockerService] = []
     try:
         for service in DOCKER_SMOKE_SERVICES:
-            _start_smoke_service(service)
+            _start_smoke_service(service, run_id)
             started_services.append(service)
             _wait_for_health(service)
             session.log("%s service is healthy on port %s", service.name, service.host_port)
     finally:
-        for service in reversed(started_services):
-            _stop_smoke_service(service)
+        if started_services:
+            _schedule_smoke_service_cleanup(run_id)
+            session.log(
+                "Smoke containers will remain available for %s minutes, then be removed.",
+                SMOKE_CONTAINER_TTL_SECONDS // 60,
+            )
 
 
 @nox.session(python=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http.client
 import os
 import shutil
 import subprocess
@@ -112,7 +113,12 @@ def _wait_for_health(service: DockerService, timeout_seconds: int = 30) -> None:
             with urllib.request.urlopen(health_url, timeout=2) as response:
                 if response.status == 200:
                     return
-        except (urllib.error.URLError, TimeoutError) as exc:
+        except (
+            ConnectionResetError,
+            http.client.RemoteDisconnected,
+            urllib.error.URLError,
+            TimeoutError,
+        ) as exc:
             last_error = exc
         time.sleep(1)
 


### PR DESCRIPTION
## Summary
- Keep Docker smoke containers running for 30 minutes after health checks pass so developers can inspect them in Docker Desktop, curl health endpoints, and review logs.
- Label each smoke run with a run id and schedule TTL cleanup that only removes containers from that run.
- Remove prior smoke containers before starting a fresh run so repeated dogfood runs do not collide on names or ports.
- Document the smoke container lifecycle and early cleanup command.

## Linear
- [FIA-154](https://linear.app/fianchetto-labs/issue/FIA-154/improve-docker-smoke-dogfooding-and-startup-readiness)

## Verification
- `python3.14 -m py_compile noxfile.py`
- `git diff --check`
- `TRADEBOT_RUN_SERVICE_TESTS=1 .venv/bin/python -m nox -s docker_smoke`
- Confirmed smoke containers remain running and healthy after Nox exits:
  - `tradebot-nox-smoke-orders` on `127.0.0.1:18080`
  - `tradebot-nox-smoke-quotes` on `127.0.0.1:18081`
  - `tradebot-nox-smoke-moex` on `127.0.0.1:18082`
- Confirmed health checks respond on all three ports.

## Notes
- Smoke containers bind only to localhost.
- The TTL is 30 minutes.
- Re-running `docker_smoke` removes prior smoke containers before starting fresh ones.
- The scheduled cleanup is scoped by a per-run Docker label so an older cleanup timer cannot remove a newer smoke run.