### PR TITLE
FIA-151: Tighten simulator contract fixtures

### DIFF
--- a/tests/fixtures/etrade_simulator_contract.py
+++ b/tests/fixtures/etrade_simulator_contract.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from urllib.parse import urlsplit
 
 from fianchetto_tradebot.common_models.api.orders.order_metadata import OrderMetadata
@@ -24,6 +24,15 @@ ACCOUNT_ID = seed_data.ACCOUNT_ID
 EQUITY_SYMBOL = seed_data.EQUITY_SYMBOL
 PREVIEW_ID = seed_data.PREVIEW_ID
 ORDER_ID = seed_data.ORDER_ID
+BALANCE_PARAMS = {"instType": "BROKERAGE", "realTimeNAV": "true"}
+PORTFOLIO_PARAMS = {
+    "count": "1000",
+    "sortBy": "DAYS_EXPIRATION",
+    "sortOrder": "ASC",
+    "view": "COMPLETE",
+}
+GET_ORDER_PARAMS = {"status": "OPEN"}
+OPTION_EXPIRY_PARAMS = {"symbol": EQUITY_SYMBOL}
 
 
 @dataclass
@@ -38,8 +47,6 @@ class RecordedRequest:
 class ContractResponse:
     body: dict
     status_code: int = HttpStatusCode.OK
-    url: str = SIM_BASE_URL
-    request: object = field(default_factory=lambda: type("_Request", (), {"headers": {}})())
 
     @property
     def text(self) -> str:
@@ -61,11 +68,13 @@ class SimulatorContractSession:
     def post(self, url: str, header_auth: bool = False, headers: dict | None = None, data: str | None = None):
         path = urlsplit(url).path
         self.requests.append(RecordedRequest("POST", path, body=data))
+        _assert_order_request("POST", path, header_auth, headers, data)
         return ContractResponse(_sync_response_for("POST", path, None))
 
     def put(self, url: str, header_auth: bool = False, headers: dict | None = None, data: str | None = None):
         path = urlsplit(url).path
         self.requests.append(RecordedRequest("PUT", path, body=data))
+        _assert_order_request("PUT", path, header_auth, headers, data)
         return ContractResponse(_sync_response_for("PUT", path, None))
 
 
@@ -123,31 +132,93 @@ def retryable_preview_error_response() -> ContractResponse:
 
 def _sync_response_for(method: str, path: str, params: dict | None) -> dict:
     routes = {
-        ("GET", "/v1/accounts/list.json"): seed_data.account_list_response(),
-        ("GET", f"/v1/accounts/{ACCOUNT_ID}/balance.json"): seed_data.balance_response(),
-        ("GET", f"/v1/accounts/{ACCOUNT_ID}/portfolio.json"): seed_data.portfolio_response(),
-        ("GET", "/v1/market/quote/GE.json"): seed_data.quote_response(EQUITY_SYMBOL),
-        ("GET", "/v1/market/quote/GE:2026:1:16:PUT:25.0.json"): seed_data.quote_response(
-            "GE:2026:1:16:PUT:25.0",
-            include_greeks=True,
+        ("GET", "/v1/accounts/list.json"): (seed_data.account_list_response(), None),
+        ("GET", f"/v1/accounts/{ACCOUNT_ID}/balance.json"): (seed_data.balance_response(), BALANCE_PARAMS),
+        ("GET", f"/v1/accounts/{ACCOUNT_ID}/portfolio.json"): (seed_data.portfolio_response(), PORTFOLIO_PARAMS),
+        ("GET", "/v1/market/quote/GE.json"): (seed_data.quote_response(EQUITY_SYMBOL), None),
+        ("GET", "/v1/market/quote/GE:2026:1:16:PUT:25.0.json"): (
+            seed_data.quote_response(
+                "GE:2026:1:16:PUT:25.0",
+                include_greeks=True,
+            ),
+            None,
         ),
-        ("GET", "/v1/market/optionexpiredate.json"): seed_data.option_expire_date_response(),
-        ("POST", f"/v1/accounts/{ACCOUNT_ID}/orders/preview.json"): seed_data.preview_order_response(),
-        ("POST", f"/v1/accounts/{ACCOUNT_ID}/orders/place.json"): seed_data.place_order_response(),
-        ("GET", f"/v1/accounts/{ACCOUNT_ID}/orders/{ORDER_ID}.json"): seed_data.get_order_response(),
-        ("PUT", f"/v1/accounts/{ACCOUNT_ID}/orders/cancel.json"): seed_data.cancel_order_response(),
+        ("GET", "/v1/market/optionexpiredate.json"): (
+            seed_data.option_expire_date_response(),
+            OPTION_EXPIRY_PARAMS,
+        ),
+        ("POST", f"/v1/accounts/{ACCOUNT_ID}/orders/preview.json"): (seed_data.preview_order_response(), None),
+        ("POST", f"/v1/accounts/{ACCOUNT_ID}/orders/place.json"): (seed_data.place_order_response(), None),
+        ("GET", f"/v1/accounts/{ACCOUNT_ID}/orders/{ORDER_ID}.json"): (
+            seed_data.get_order_response(),
+            GET_ORDER_PARAMS,
+        ),
+        ("PUT", f"/v1/accounts/{ACCOUNT_ID}/orders/cancel.json"): (seed_data.cancel_order_response(), None),
     }
     try:
-        return routes[(method, path)]
+        response, expected_params = routes[(method, path)]
     except KeyError as exc:
         raise AssertionError(f"Simulator contract has no seed response for {method} {path} {params}") from exc
+    _assert_params(method, path, params, expected_params)
+    return response
 
 
 def _async_response_for(method: str, path: str, params: dict | None) -> dict:
     if method == "GET" and path == "/v1/market/optionchains.json":
+        _assert_option_chain_params(method, path, params)
         return seed_data.option_chain_response(
             year=int(params["expiryYear"]),
             month=int(params["expiryMonth"]),
             day=int(params["expiryDay"]),
         )
     raise AssertionError(f"Simulator contract has no async seed response for {method} {path} {params}")
+
+
+def _assert_params(method: str, path: str, actual: dict | None, expected: dict | None) -> None:
+    if actual != expected:
+        raise AssertionError(f"Expected {method} {path} params {expected}, got {actual}")
+
+
+def _assert_option_chain_params(method: str, path: str, params: dict | None) -> None:
+    expected_keys = {"symbol", "expiryYear", "expiryMonth", "expiryDay"}
+    if params is None:
+        raise AssertionError(f"Expected {method} {path} params with keys {expected_keys}, got None")
+
+    actual_keys = set(params)
+    if actual_keys != expected_keys:
+        raise AssertionError(f"Expected {method} {path} params keys {expected_keys}, got {actual_keys}")
+
+    if params["symbol"] != EQUITY_SYMBOL:
+        raise AssertionError(f"Expected {method} {path} symbol {EQUITY_SYMBOL}, got {params['symbol']}")
+
+
+def _assert_order_request(
+    method: str,
+    path: str,
+    header_auth: bool,
+    headers: dict | None,
+    body: str | None,
+) -> None:
+    if "/orders/" not in path:
+        return
+
+    expected_headers = {"Content-Type": "application/xml", "consumerKey": ACCOUNT_ID}
+    if not header_auth:
+        raise AssertionError(f"Expected {method} {path} to use header authentication")
+    if headers != expected_headers:
+        raise AssertionError(f"Expected {method} {path} headers {expected_headers}, got {headers}")
+    if body is None:
+        raise AssertionError(f"Expected {method} {path} XML body")
+
+    if path.endswith("/orders/preview.json"):
+        _assert_body_contains(method, path, body, "<PreviewOrderRequest>", "<clientOrderId>client-1</clientOrderId>")
+    elif path.endswith("/orders/place.json"):
+        _assert_body_contains(method, path, body, "<PlaceOrderRequest>", f"<previewId>{PREVIEW_ID}</previewId>")
+    elif path.endswith("/orders/cancel.json"):
+        _assert_body_contains(method, path, body, "<CancelOrderRequest>", f"<orderId>{ORDER_ID}</orderId>")
+
+
+def _assert_body_contains(method: str, path: str, body: str, *snippets: str) -> None:
+    missing = [snippet for snippet in snippets if snippet not in body]
+    if missing:
+        raise AssertionError(f"Expected {method} {path} body to contain {missing}")


### PR DESCRIPTION
## Summary
- Rebase follow-up work onto `main` after PR #67 merged.
- Make the E*Trade simulator contract fixture stricter about the service/request boundary.
- Validate expected query params before returning seed responses for account balance, portfolio, order lookup, option expiries, and option chains.
- Validate order request header auth, XML headers, and stable request-body snippets for preview, place, and cancel flows.
- Remove unused fake response surface that exposed `url` and `request.headers` even though no current parser needs it.

## Linear
- [FIA-151](https://linear.app/fianchetto-labs/issue/FIA-151/add-pytest-markers-and-test-layout-conventions-for-the-test-pyramid)

## Verification
- `python3.14 -m py_compile tests/fixtures/etrade_simulator_contract.py tests/common/api/etrade_simulator/test_etrade_simulator_contract.py`
- `.venv/bin/python -m pytest tests/common/api/etrade_simulator/test_etrade_simulator_contract.py tests/common/api/etrade_simulator/test_etrade_simulator_app.py -q -s` -> 10 passed, quiet output
- `.venv/bin/python -m nox -s functional` -> 17 passed, 176 deselected
- `.venv/bin/python -m nox -s unit` -> 176 passed, 17 deselected
- `git diff --check`

## Notes
- I intentionally did not add tests that only exercise the fixture itself. The value here is that existing tests still drive real E*Trade services/parsers, while the fixture now fails fast if those services send the wrong boundary contract.