### PR TITLE
FIA-149/FIA-155: Add simulator-backed Docker integration slices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,11 @@ RUN adduser \
 
 COPY pyproject.toml README.md LICENSE ./
 COPY src ./src
-COPY deploy ./deploy
 
 RUN python -m pip install --upgrade pip \
     && python -m pip install -e .
+
+COPY deploy ./deploy
 
 USER tradebot
 

--- a/deploy/docker/docker-compose.integration.yml
+++ b/deploy/docker/docker-compose.integration.yml
@@ -1,9 +1,15 @@
 name: tradebot-integration
 
+x-tradebot-integration-labels: &tradebot-integration-labels
+  fianchetto.tradebot.kind: docker-integration
+  fianchetto.tradebot.run-id: ${TRADEBOT_INTEGRATION_RUN_ID:-manual}
+  fianchetto.tradebot.ttl-seconds: ${TRADEBOT_INTEGRATION_STACK_TTL_SECONDS:-1800}
+
 services:
   etrade-simulator:
     image: ${TRADEBOT_DOCKER_IMAGE:-tradebot:local}
     command: python -m fianchetto_tradebot.server.simulator.etrade
+    labels: *tradebot-integration-labels
     environment:
       TRADEBOT_ETRADE_SIMULATOR_HOST: 0.0.0.0
       TRADEBOT_ETRADE_SIMULATOR_PORT: "8090"
@@ -24,6 +30,7 @@ services:
   quotes:
     image: ${TRADEBOT_DOCKER_IMAGE:-tradebot:local}
     command: python -m fianchetto_tradebot.server.quotes.serving.quotes_rest_service
+    labels: *tradebot-integration-labels
     environment:
       FIANCHETTO_TRADEBOT_STATE_DIR: /app/deploy/docker/demo-state
       TRADEBOT_ETRADE_API_BASE_URL: http://etrade-simulator:8090
@@ -48,6 +55,7 @@ services:
   orders:
     image: ${TRADEBOT_DOCKER_IMAGE:-tradebot:local}
     command: python -m fianchetto_tradebot.server.orders.serving.orders_rest_service
+    labels: *tradebot-integration-labels
     environment:
       FIANCHETTO_TRADEBOT_STATE_DIR: /app/deploy/docker/demo-state
       TRADEBOT_ETRADE_API_BASE_URL: http://etrade-simulator:8090
@@ -68,3 +76,7 @@ services:
       timeout: 3s
       retries: 20
       start_period: 5s
+
+networks:
+  default:
+    labels: *tradebot-integration-labels

--- a/deploy/docker/docker-compose.integration.yml
+++ b/deploy/docker/docker-compose.integration.yml
@@ -44,3 +44,27 @@ services:
       timeout: 3s
       retries: 20
       start_period: 5s
+
+  orders:
+    image: ${TRADEBOT_DOCKER_IMAGE:-tradebot:local}
+    command: python -m fianchetto_tradebot.server.orders.serving.orders_rest_service
+    environment:
+      FIANCHETTO_TRADEBOT_STATE_DIR: /app/deploy/docker/demo-state
+      TRADEBOT_ETRADE_API_BASE_URL: http://etrade-simulator:8090
+      TRADEBOT_ETRADE_CACHE_MAX_AGE_SECONDS: "315360000"
+      TRADEBOT_HEALTHCHECK_PORT: "8080"
+    ports:
+      - "127.0.0.1:18080:8080"
+    depends_on:
+      etrade-simulator:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/health-check', timeout=2).read()"
+      interval: 2s
+      timeout: 3s
+      retries: 20
+      start_period: 5s

--- a/deploy/docker/docker-compose.integration.yml
+++ b/deploy/docker/docker-compose.integration.yml
@@ -1,0 +1,46 @@
+name: tradebot-integration
+
+services:
+  etrade-simulator:
+    image: ${TRADEBOT_DOCKER_IMAGE:-tradebot:local}
+    command: python -m fianchetto_tradebot.server.simulator.etrade
+    environment:
+      TRADEBOT_ETRADE_SIMULATOR_HOST: 0.0.0.0
+      TRADEBOT_ETRADE_SIMULATOR_PORT: "8090"
+      TRADEBOT_HEALTHCHECK_PORT: "8090"
+    ports:
+      - "127.0.0.1:18090:8090"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8090/health-check', timeout=2).read()"
+      interval: 2s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
+  quotes:
+    image: ${TRADEBOT_DOCKER_IMAGE:-tradebot:local}
+    command: python -m fianchetto_tradebot.server.quotes.serving.quotes_rest_service
+    environment:
+      FIANCHETTO_TRADEBOT_STATE_DIR: /app/deploy/docker/demo-state
+      TRADEBOT_ETRADE_API_BASE_URL: http://etrade-simulator:8090
+      TRADEBOT_ETRADE_CACHE_MAX_AGE_SECONDS: "315360000"
+      TRADEBOT_HEALTHCHECK_PORT: "8081"
+    ports:
+      - "127.0.0.1:18081:8081"
+    depends_on:
+      etrade-simulator:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8081/health-check', timeout=2).read()"
+      interval: 2s
+      timeout: 3s
+      retries: 20
+      start_period: 5s

--- a/docs/docker-poc.md
+++ b/docs/docker-poc.md
@@ -4,9 +4,10 @@ FIA-133 introduces one reusable image for local container startup checks. The
 image can run each current REST service by selecting the Python module at
 container start.
 
-This is not the full Docker Compose topology. Compose networking, service DNS,
-and simulator-backed service-to-service checks belong to FIA-136, FIA-148, and
-FIA-149.
+The first Compose-backed integration slice starts the E*Trade simulator and the
+quotes service together. The quotes service reaches the simulator through Docker
+service DNS, so this proves more than container startup: it proves endpoint
+configuration, service networking, and a representative TradeBot HTTP route.
 
 ## Build
 
@@ -33,12 +34,22 @@ FIANCHETTO_TRADEBOT_STATE_DIR=/app/deploy/docker/demo-state
 ```
 
 The demo state contains fake OAuth-shaped E*Trade values. They are intentionally
-not live brokerage credentials. A later simulator-backed Compose profile should
-override the API endpoint with service DNS, for example:
+not live brokerage credentials. The simulator-backed Compose profile overrides
+the API endpoint with service DNS:
 
 ```bash
-TRADEBOT_ETRADE_API_BASE_URL=http://etrade-sim:8090
+TRADEBOT_ETRADE_API_BASE_URL=http://etrade-simulator:8090
 ```
+
+It also sets a long cache max age for that fake credential document:
+
+```bash
+TRADEBOT_ETRADE_CACHE_MAX_AGE_SECONDS=315360000
+```
+
+The default cache max age remains one hour for normal connector use. The longer
+value is for checked-in simulator credentials only; the credential fields are
+still validated before the service starts.
 
 ## Run One Service
 
@@ -82,3 +93,25 @@ curl http://127.0.0.1:8080/health-check
 ```
 
 Change the port to match the service under test.
+
+## Run The Simulator-Backed Stack
+
+Use Nox for the automated Docker integration run:
+
+```bash
+TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_integration
+```
+
+That command builds `tradebot:local`, starts the Compose stack in
+`deploy/docker/docker-compose.integration.yml`, waits for service health, runs
+the Docker integration tests, and tears the stack down.
+
+To inspect the stack manually:
+
+```bash
+docker build --build-arg PYTHON_VERSION=3.14 -t tradebot:local .
+docker compose -f deploy/docker/docker-compose.integration.yml up --detach --wait
+curl http://127.0.0.1:18090/health-check
+curl http://127.0.0.1:18081/api/v1/ETRADE/quotes/tradable/GE
+docker compose -f deploy/docker/docker-compose.integration.yml down --volumes
+```

--- a/docs/docker-poc.md
+++ b/docs/docker-poc.md
@@ -104,7 +104,9 @@ TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_integration
 
 That command builds `tradebot:local`, starts the Compose stack in
 `deploy/docker/docker-compose.integration.yml`, waits for service health, runs
-the Docker integration tests, and tears the stack down.
+the Docker integration tests, and leaves the stack available for 30 minutes on
+local machines. CI runs and local runs with
+`TRADEBOT_INTEGRATION_STACK_TTL_SECONDS=0` tear the stack down immediately.
 
 To inspect the stack manually:
 

--- a/docs/docker-poc.md
+++ b/docs/docker-poc.md
@@ -4,10 +4,10 @@ FIA-133 introduces one reusable image for local container startup checks. The
 image can run each current REST service by selecting the Python module at
 container start.
 
-The first Compose-backed integration slice starts the E*Trade simulator and the
-quotes service together. The quotes service reaches the simulator through Docker
+The first Compose-backed integration slices start the E*Trade simulator plus the
+quotes and orders services. TradeBot services reach the simulator through Docker
 service DNS, so this proves more than container startup: it proves endpoint
-configuration, service networking, and a representative TradeBot HTTP route.
+configuration, service networking, and representative TradeBot HTTP routes.
 
 ## Build
 
@@ -112,6 +112,7 @@ To inspect the stack manually:
 docker build --build-arg PYTHON_VERSION=3.14 -t tradebot:local .
 docker compose -f deploy/docker/docker-compose.integration.yml up --detach --wait
 curl http://127.0.0.1:18090/health-check
+curl http://127.0.0.1:18080/health-check
 curl http://127.0.0.1:18081/api/v1/ETRADE/quotes/tradable/GE
 docker compose -f deploy/docker/docker-compose.integration.yml down --volumes
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -119,12 +119,18 @@ To clean them up early:
 docker rm -f tradebot-nox-smoke-orders tradebot-nox-smoke-quotes tradebot-nox-smoke-moex
 ```
 
-The Docker integration session is reserved for the Docker Compose and reusable
-service lifecycle work in FIA-136, FIA-149, and FIA-152:
+Run the simulator-backed Docker integration slice intentionally:
 
 ```bash
 TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_integration
 ```
+
+This builds the local image, starts the Compose stack, waits for health checks,
+runs Docker integration tests, and tears the stack down. The first slice verifies
+host pytest -> quotes service container -> E*Trade simulator container -> quotes
+service container -> host assertion. That catches broken Docker DNS, port
+mapping, service startup ordering, connector base URL configuration, and
+response serialization across a real HTTP/process boundary.
 
 The live paper-account E*Trade session is reserved for FIA-153 and must remain
 separately gated:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -119,6 +119,10 @@ To clean them up early:
 docker rm -f tradebot-nox-smoke-orders tradebot-nox-smoke-quotes tradebot-nox-smoke-moex
 ```
 
+Smoke tests are startup probes. They prove a service process can boot from the
+Docker image and answer its health check, but they do not prove service-to-service
+behavior or a user workflow.
+
 Run the simulator-backed Docker integration slice intentionally:
 
 ```bash
@@ -126,12 +130,28 @@ TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_integration
 ```
 
 This builds the local image, starts the Compose stack, waits for health checks,
-runs Docker integration tests, and tears the stack down. The current slices
-verify host pytest -> TradeBot service container -> E*Trade simulator container
--> TradeBot service container -> host assertion for quotes and orders. That
-catches broken Docker DNS, port mapping, service startup ordering, connector
-base URL configuration, request/response serialization, and order lifecycle
-behavior across a real HTTP/process boundary.
+runs Docker integration tests, and leaves the stack available for 30 minutes on
+local machines. The current slices verify host pytest -> TradeBot service
+container -> E*Trade simulator container -> TradeBot service container -> host
+assertion for quotes and orders. That catches broken Docker DNS, port mapping,
+service startup ordering, connector base URL configuration, request/response
+serialization, and order lifecycle behavior across a real HTTP/process boundary.
+
+Integration cleanup is intentionally automatic. Local runs schedule cleanup by
+run-specific Docker labels so an old cleanup task does not remove a newer run.
+Each integration run removes any previous integration stack before starting a
+fresh one. CI always tears the stack down immediately. To make a local run clean
+up immediately, set:
+
+```bash
+TRADEBOT_RUN_SERVICE_TESTS=1 TRADEBOT_INTEGRATION_STACK_TTL_SECONDS=0 python -m nox -s docker_integration
+```
+
+To clean the integration stack up early:
+
+```bash
+docker compose -f deploy/docker/docker-compose.integration.yml down --volumes --remove-orphans
+```
 
 The live paper-account E*Trade session is reserved for FIA-153 and must remain
 separately gated:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -126,11 +126,12 @@ TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_integration
 ```
 
 This builds the local image, starts the Compose stack, waits for health checks,
-runs Docker integration tests, and tears the stack down. The first slice verifies
-host pytest -> quotes service container -> E*Trade simulator container -> quotes
-service container -> host assertion. That catches broken Docker DNS, port
-mapping, service startup ordering, connector base URL configuration, and
-response serialization across a real HTTP/process boundary.
+runs Docker integration tests, and tears the stack down. The current slices
+verify host pytest -> TradeBot service container -> E*Trade simulator container
+-> TradeBot service container -> host assertion for quotes and orders. That
+catches broken Docker DNS, port mapping, service startup ordering, connector
+base URL configuration, request/response serialization, and order lifecycle
+behavior across a real HTTP/process boundary.
 
 The live paper-account E*Trade session is reserved for FIA-153 and must remain
 separately gated:

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,6 +24,7 @@ LIVE_E2E_TEST_ENV_VAR = "TRADEBOT_RUN_LIVE_E2E_TESTS"
 DOCKER_IMAGE = os.environ.get("TRADEBOT_DOCKER_IMAGE", "tradebot:local")
 SMOKE_CONTAINER_TTL_SECONDS = 30 * 60
 REPO_ROOT = Path(__file__).parent
+DOCKER_INTEGRATION_COMPOSE_FILE = REPO_ROOT / "deploy" / "docker" / "docker-compose.integration.yml"
 UNIT_PYTEST_MARKER_EXPR = "not functional and not contract and not service and not docker and not integration and not live_e2e"
 FUNCTIONAL_PYTEST_MARKER_EXPR = "functional and not service and not docker and not integration and not live_e2e"
 
@@ -104,6 +105,18 @@ def _run_docker_command(*args: str) -> subprocess.CompletedProcess[str]:
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+    )
+
+
+def _run_docker_compose(session: nox.Session, *args: str) -> None:
+    session.run(
+        "docker",
+        "compose",
+        "-f",
+        str(DOCKER_INTEGRATION_COMPOSE_FILE),
+        *args,
+        external=True,
+        env={**os.environ, "TRADEBOT_DOCKER_IMAGE": DOCKER_IMAGE},
     )
 
 
@@ -241,11 +254,33 @@ def docker_smoke(session: nox.Session) -> None:
             )
 
 
-@nox.session(python=False)
+@nox.session(python=PYTHON, venv_backend="venv", download_python="never")
 def docker_integration(session: nox.Session) -> None:
-    """Reserved for Docker Compose/service-boundary tests."""
+    """Build the image, run the simulator-backed Compose stack, and execute Docker tests."""
     _require_env_gate(session, SERVICE_TEST_ENV_VAR, "Docker-backed integration tests")
-    session.error("Docker integration orchestration belongs to FIA-136/FIA-149/FIA-152")
+    _install_project(session)
+    _docker_build(session)
+
+    try:
+        _run_docker_compose(session, "up", "--detach", "--wait", "--remove-orphans")
+        session.run(
+            "python",
+            "-m",
+            "pytest",
+            "-m",
+            "docker and integration",
+            "tests/integration/docker",
+            env={
+                **os.environ,
+                SERVICE_TEST_ENV_VAR: "1",
+                "TRADEBOT_TEST_QUOTES_BASE_URL": "http://127.0.0.1:18081",
+            },
+        )
+    except Exception:
+        _run_docker_compose(session, "logs", "--no-color")
+        raise
+    finally:
+        _run_docker_compose(session, "down", "--volumes", "--remove-orphans")
 
 
 @nox.session(python=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -273,6 +273,7 @@ def docker_integration(session: nox.Session) -> None:
             env={
                 **os.environ,
                 SERVICE_TEST_ENV_VAR: "1",
+                "TRADEBOT_TEST_ORDERS_BASE_URL": "http://127.0.0.1:18080",
                 "TRADEBOT_TEST_QUOTES_BASE_URL": "http://127.0.0.1:18081",
             },
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,8 @@ SERVICE_TEST_ENV_VAR = "TRADEBOT_RUN_SERVICE_TESTS"
 LIVE_E2E_TEST_ENV_VAR = "TRADEBOT_RUN_LIVE_E2E_TESTS"
 DOCKER_IMAGE = os.environ.get("TRADEBOT_DOCKER_IMAGE", "tradebot:local")
 SMOKE_CONTAINER_TTL_SECONDS = 30 * 60
+INTEGRATION_STACK_TTL_ENV_VAR = "TRADEBOT_INTEGRATION_STACK_TTL_SECONDS"
+DEFAULT_INTEGRATION_STACK_TTL_SECONDS = 30 * 60
 REPO_ROOT = Path(__file__).parent
 DOCKER_INTEGRATION_COMPOSE_FILE = REPO_ROOT / "deploy" / "docker" / "docker-compose.integration.yml"
 UNIT_PYTEST_MARKER_EXPR = "not functional and not contract and not service and not docker and not integration and not live_e2e"
@@ -108,7 +110,7 @@ def _run_docker_command(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _run_docker_compose(session: nox.Session, *args: str) -> None:
+def _run_docker_compose(session: nox.Session, *args: str, env: dict[str, str] | None = None) -> None:
     session.run(
         "docker",
         "compose",
@@ -116,7 +118,7 @@ def _run_docker_compose(session: nox.Session, *args: str) -> None:
         str(DOCKER_INTEGRATION_COMPOSE_FILE),
         *args,
         external=True,
-        env={**os.environ, "TRADEBOT_DOCKER_IMAGE": DOCKER_IMAGE},
+        env=env or {**os.environ, "TRADEBOT_DOCKER_IMAGE": DOCKER_IMAGE},
     )
 
 
@@ -191,6 +193,67 @@ def _schedule_smoke_service_cleanup(run_id: str) -> None:
     )
 
 
+def _integration_stack_ttl_seconds(session: nox.Session) -> int:
+    if os.getenv("CI") or os.getenv("GITHUB_ACTIONS"):
+        return 0
+
+    raw_ttl = os.getenv(INTEGRATION_STACK_TTL_ENV_VAR)
+    if raw_ttl is None:
+        return DEFAULT_INTEGRATION_STACK_TTL_SECONDS
+
+    try:
+        ttl_seconds = int(raw_ttl)
+    except ValueError:
+        session.error(f"{INTEGRATION_STACK_TTL_ENV_VAR} must be a non-negative integer number of seconds")
+
+    if ttl_seconds < 0:
+        session.error(f"{INTEGRATION_STACK_TTL_ENV_VAR} must be a non-negative integer number of seconds")
+    return ttl_seconds
+
+
+def _integration_compose_env(run_id: str, ttl_seconds: int) -> dict[str, str]:
+    return {
+        **os.environ,
+        "TRADEBOT_DOCKER_IMAGE": DOCKER_IMAGE,
+        "TRADEBOT_INTEGRATION_RUN_ID": run_id,
+        INTEGRATION_STACK_TTL_ENV_VAR: str(ttl_seconds),
+    }
+
+
+def _schedule_integration_stack_cleanup(run_id: str, ttl_seconds: int) -> None:
+    cleanup_script = (
+        "import subprocess, sys, time; "
+        "time.sleep(int(sys.argv[1])); "
+        "run_id = sys.argv[2]; "
+        "filters = ['--filter', 'label=fianchetto.tradebot.kind=docker-integration', "
+        "'--filter', f'label=fianchetto.tradebot.run-id={run_id}']; "
+        "containers = subprocess.run(['docker', 'ps', '-a', *filters, '--format', '{{.ID}}'], "
+        "stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, check=False).stdout.splitlines(); "
+        "containers and subprocess.run(['docker', 'rm', '-f', *containers], "
+        "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False); "
+        "networks = subprocess.run(['docker', 'network', 'ls', *filters, '--format', '{{.ID}}'], "
+        "stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, check=False).stdout.splitlines(); "
+        "networks and subprocess.run(['docker', 'network', 'rm', *networks], "
+        "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)"
+    )
+    subprocess.Popen(
+        [sys.executable, "-c", cleanup_script, str(ttl_seconds), run_id],
+        cwd=REPO_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def _format_duration(seconds: int) -> str:
+    if seconds % 60 == 0:
+        minutes = seconds // 60
+        unit = "minute" if minutes == 1 else "minutes"
+        return f"{minutes} {unit}"
+    unit = "second" if seconds == 1 else "seconds"
+    return f"{seconds} {unit}"
+
+
 def _stop_smoke_service(service: DockerService) -> None:
     subprocess.run(
         ["docker", "rm", "-f", _container_name(service)],
@@ -261,8 +324,13 @@ def docker_integration(session: nox.Session) -> None:
     _install_project(session)
     _docker_build(session)
 
+    run_id = uuid.uuid4().hex
+    ttl_seconds = _integration_stack_ttl_seconds(session)
+    compose_env = _integration_compose_env(run_id, ttl_seconds)
+
     try:
-        _run_docker_compose(session, "up", "--detach", "--wait", "--remove-orphans")
+        _run_docker_compose(session, "down", "--volumes", "--remove-orphans", env=compose_env)
+        _run_docker_compose(session, "up", "--detach", "--wait", "--remove-orphans", env=compose_env)
         session.run(
             "python",
             "-m",
@@ -278,10 +346,19 @@ def docker_integration(session: nox.Session) -> None:
             },
         )
     except Exception:
-        _run_docker_compose(session, "logs", "--no-color")
+        _run_docker_compose(session, "logs", "--no-color", env=compose_env)
         raise
     finally:
-        _run_docker_compose(session, "down", "--volumes", "--remove-orphans")
+        if ttl_seconds:
+            _schedule_integration_stack_cleanup(run_id, ttl_seconds)
+            session.log(
+                "Integration containers will remain available for %s, then be removed. "
+                "Set %s=0 to clean up immediately.",
+                _format_duration(ttl_seconds),
+                INTEGRATION_STACK_TTL_ENV_VAR,
+            )
+        else:
+            _run_docker_compose(session, "down", "--volumes", "--remove-orphans", env=compose_env)
 
 
 @nox.session(python=False)

--- a/src/fianchetto_tradebot/server/common/api/accounts/etrade/etrade_account_service.py
+++ b/src/fianchetto_tradebot/server/common/api/accounts/etrade/etrade_account_service.py
@@ -24,7 +24,7 @@ class ETradeAccountService(AccountService):
     def list_accounts(self) -> ListAccountsResponse:
         path = f"/v1/accounts/list.json"
         url = self.base_url + path
-        response = self.session.get(url)
+        response = self.session.get(url, params={})
         account_list_response = ETradeAccountService._parse_account_list_response(response)
         return ListAccountsResponse(account_list=account_list_response)
 
@@ -47,7 +47,7 @@ class ETradeAccountService(AccountService):
     def get_account_info(self, get_account_info_request: GetAccountRequest) -> GetAccountResponse:
         path = f"/v1/accounts/list.json"
         url = self.base_url + path
-        response = self.session.get(url)
+        response = self.session.get(url, params={})
 
         name_filter = (lambda a: a.account_id_key == get_account_info_request.account_id)
 

--- a/src/fianchetto_tradebot/server/common/brokerage/etrade/etrade_connector.py
+++ b/src/fianchetto_tradebot/server/common/brokerage/etrade/etrade_connector.py
@@ -29,6 +29,8 @@ DEFAULT_SESSION_FILE = DEFAULT_CREDENTIALS_FILE
 DEFAULT_ASYNC_SESSION_FILE = DEFAULT_CREDENTIALS_FILE
 DEFAULT_ETRADE_BASE_URL_FILE = os.path.join(BROKERAGE_STATE_DIR, "base_url.json")
 ETRADE_API_BASE_URL_ENV_VAR = "TRADEBOT_ETRADE_API_BASE_URL"
+ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR = "TRADEBOT_ETRADE_CACHE_MAX_AGE_SECONDS"
+DEFAULT_CACHE_MAX_AGE_SECONDS = 60 * 60
 REQUIRED_CREDENTIAL_FIELDS = (
     "consumer_key",
     "consumer_secret",
@@ -104,14 +106,18 @@ class ETradeConnector(Connector):
         return None
 
     def _load_valid_connection_credentials(self) -> dict | None:
-        if not ETradeConnector.is_file_still_valid(self.credentials_file):
+        if not ETradeConnector.is_file_still_valid(
+                self.credentials_file,
+                max_age=self._cache_max_age()):
             return None
         return ETradeConnector._validate_connection_credentials(
             ETradeConnector._deserialize_connection_credentials(self.credentials_file)
         )
 
     def _load_valid_standalone_base_url(self) -> str | None:
-        if not ETradeConnector.is_file_still_valid(self.base_url_file):
+        if not ETradeConnector.is_file_still_valid(
+                self.base_url_file,
+                max_age=self._cache_max_age()):
             return None
         return ETradeConnector.deserialize_base_url(self.base_url_file)
 
@@ -120,6 +126,20 @@ class ETradeConnector(Connector):
         if not raw_base_url:
             return None
         return ETradeConnector._normalize_base_url(raw_base_url, ETRADE_API_BASE_URL_ENV_VAR)
+
+    def _cache_max_age(self) -> datetime.timedelta:
+        raw_max_age = self.env.get(ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR)
+        if raw_max_age is None:
+            return datetime.timedelta(seconds=DEFAULT_CACHE_MAX_AGE_SECONDS)
+        try:
+            max_age_seconds = int(raw_max_age)
+        except ValueError as exc:
+            raise ValueError(
+                f"E*Trade {ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR} must be a positive integer"
+            ) from exc
+        if max_age_seconds <= 0:
+            raise ValueError(f"E*Trade {ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR} must be positive")
+        return datetime.timedelta(seconds=max_age_seconds)
 
     def establish_connection(self) -> (OAuth1Session, OAuth1Client, str):
         config.read(self.config_file)

--- a/src/fianchetto_tradebot/server/quotes/etrade/etrade_quotes_service.py
+++ b/src/fianchetto_tradebot/server/quotes/etrade/etrade_quotes_service.py
@@ -48,7 +48,7 @@ class ETradeQuotesService(QuotesService):
 
         path = f"/v1/market/quote/{symbols}.json"
         url = self.base_url + path
-        response = self.session.get(url)
+        response = self.session.get(url, params={})
 
         tradable_response: GetTradableResponse = ETradeQuotesService._parse_market_response(tradable, response)
 

--- a/tests/common/api/etrade/test_etrade_connector_config.py
+++ b/tests/common/api/etrade/test_etrade_connector_config.py
@@ -1,5 +1,7 @@
 import json
+import os
 import stat
+import time
 from unittest.mock import patch
 
 import pytest
@@ -8,6 +10,7 @@ from rauth import OAuth1Session
 
 from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import (
     ETRADE_API_BASE_URL_ENV_VAR,
+    ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR,
     ETradeConnector,
 )
 
@@ -190,6 +193,53 @@ def test_configured_endpoint_does_not_skip_credentials(tmp_path):
             )
 
 
+def test_stale_credential_cache_falls_back_to_connection_establishment(tmp_path):
+    credentials_file = tmp_path / "connection.json"
+    _write_credentials(credentials_file, base_url="http://etrade-sim:8090")
+    _make_old(credentials_file)
+
+    with patch.object(ETradeConnector, "establish_connection", side_effect=RuntimeError("credentials expired")):
+        with pytest.raises(RuntimeError, match="credentials expired"):
+            ETradeConnector(
+                config_file=str(tmp_path / "missing-config.ini"),
+                session_file=str(credentials_file),
+                async_session_file=str(credentials_file),
+                base_url_file=str(tmp_path / "missing-base-url.json"),
+                env={},
+            )
+
+
+def test_configured_cache_max_age_keeps_valid_demo_credentials_usable(tmp_path):
+    credentials_file = tmp_path / "connection.json"
+    _write_credentials(credentials_file, base_url="http://etrade-sim:8090")
+    _make_old(credentials_file)
+
+    connector = ETradeConnector(
+        config_file=str(tmp_path / "missing-config.ini"),
+        session_file=str(credentials_file),
+        async_session_file=str(credentials_file),
+        base_url_file=str(tmp_path / "missing-base-url.json"),
+        env={ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR: str(10 * 365 * 24 * 60 * 60)},
+    )
+
+    assert connector.base_url == "http://etrade-sim:8090"
+    assert connector.async_session.oauth_token == "simulator-access-token"
+
+
+def test_connector_rejects_invalid_cache_max_age(tmp_path):
+    credentials_file = tmp_path / "connection.json"
+    _write_credentials(credentials_file, base_url="http://etrade-sim:8090")
+
+    with pytest.raises(ValueError, match=ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR):
+        ETradeConnector(
+            config_file=str(tmp_path / "missing-config.ini"),
+            session_file=str(credentials_file),
+            async_session_file=str(credentials_file),
+            base_url_file=str(tmp_path / "missing-base-url.json"),
+            env={ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR: "0"},
+        )
+
+
 def _write_credentials(credentials_file, **overrides) -> None:
     connector = object.__new__(ETradeConnector)
     connector.credentials_file = str(credentials_file)
@@ -222,3 +272,8 @@ def _credentials_dict(**overrides) -> dict:
     }
     credentials.update(overrides)
     return credentials
+
+
+def _make_old(path) -> None:
+    old_timestamp = time.time() - (2 * 60 * 60)
+    os.utime(path, (old_timestamp, old_timestamp))

--- a/tests/common/api/etrade/test_etrade_quotes_service.py
+++ b/tests/common/api/etrade/test_etrade_quotes_service.py
@@ -1,0 +1,31 @@
+from fianchetto_tradebot.common_models.api.quotes.get_tradable_request import GetTradableRequest
+from fianchetto_tradebot.common_models.finance.equity import Equity
+from fianchetto_tradebot.server.quotes.etrade.etrade_quotes_service import ETradeQuotesService
+from fianchetto_tradebot.server.simulator.etrade import seed_data
+
+
+def test_equity_quote_request_sends_explicit_empty_params():
+    session = StrictGetSession()
+    service = object.__new__(ETradeQuotesService)
+    service.session = session
+    service.base_url = "http://etrade-simulator:8090"
+
+    response = service.get_tradable_quote(GetTradableRequest(tradable=Equity(ticker="GE")))
+
+    assert session.requested_url == "http://etrade-simulator:8090/v1/market/quote/GE.json"
+    assert response.current_price.bid == 100.0
+    assert response.current_price.ask == 101.0
+
+
+class StrictGetSession:
+    requested_url: str | None = None
+
+    def get(self, url: str, *, params: dict):
+        self.requested_url = url
+        assert params == {}
+        return QuoteResponse()
+
+
+class QuoteResponse:
+    def json(self):
+        return seed_data.quote_response("GE")

--- a/tests/common/api/etrade_simulator/test_etrade_simulator_contract.py
+++ b/tests/common/api/etrade_simulator/test_etrade_simulator_contract.py
@@ -57,7 +57,7 @@ def test_simulator_contract_supports_account_balance_and_portfolio_paths():
 
     # And
     # The future simulator must support the exact routes and query params the services call.
-    assert connector.session.requests[0] == RecordedRequest("GET", "/v1/accounts/list.json", params=None)
+    assert connector.session.requests[0] == RecordedRequest("GET", "/v1/accounts/list.json", params={})
     assert connector.session.requests[1] == RecordedRequest(
         "GET",
         f"/v1/accounts/{ACCOUNT_ID}/balance.json",
@@ -97,8 +97,12 @@ def test_simulator_contract_supports_quotes_expiries_and_option_chains():
 
     # And
     # The future simulator must support the same sync quote routes and async chain route.
-    assert connector.session.requests[0].path == "/v1/market/quote/GE.json"
-    assert connector.session.requests[1].path == "/v1/market/quote/GE:2026:1:16:PUT:25.0.json"
+    assert connector.session.requests[0] == RecordedRequest("GET", "/v1/market/quote/GE.json", params={})
+    assert connector.session.requests[1] == RecordedRequest(
+        "GET",
+        "/v1/market/quote/GE:2026:1:16:PUT:25.0.json",
+        params={},
+    )
     assert connector.session.requests[2] == RecordedRequest(
         "GET",
         "/v1/market/optionexpiredate.json",

--- a/tests/fixtures/etrade_simulator_contract.py
+++ b/tests/fixtures/etrade_simulator_contract.py
@@ -132,16 +132,16 @@ def retryable_preview_error_response() -> ContractResponse:
 
 def _sync_response_for(method: str, path: str, params: dict | None) -> dict:
     routes = {
-        ("GET", "/v1/accounts/list.json"): (seed_data.account_list_response(), None),
+        ("GET", "/v1/accounts/list.json"): (seed_data.account_list_response(), {}),
         ("GET", f"/v1/accounts/{ACCOUNT_ID}/balance.json"): (seed_data.balance_response(), BALANCE_PARAMS),
         ("GET", f"/v1/accounts/{ACCOUNT_ID}/portfolio.json"): (seed_data.portfolio_response(), PORTFOLIO_PARAMS),
-        ("GET", "/v1/market/quote/GE.json"): (seed_data.quote_response(EQUITY_SYMBOL), None),
+        ("GET", "/v1/market/quote/GE.json"): (seed_data.quote_response(EQUITY_SYMBOL), {}),
         ("GET", "/v1/market/quote/GE:2026:1:16:PUT:25.0.json"): (
             seed_data.quote_response(
                 "GE:2026:1:16:PUT:25.0",
                 include_greeks=True,
             ),
-            None,
+            {},
         ),
         ("GET", "/v1/market/optionexpiredate.json"): (
             seed_data.option_expire_date_response(),

--- a/tests/integration/docker/test_orders_service_stack.py
+++ b/tests/integration/docker/test_orders_service_stack.py
@@ -1,0 +1,71 @@
+import os
+
+import httpx
+import pytest
+
+from fianchetto_tradebot.common_models.api.orders.place_order_request import PlaceOrderRequest
+from fianchetto_tradebot.server.common.api.http_status_code import HttpStatusCode
+from tests.fixtures.etrade_simulator_contract import ACCOUNT_ID
+from tests.fixtures.etrade_simulator_contract import ORDER_ID
+from tests.fixtures.etrade_simulator_contract import demo_preview_order_request
+
+
+pytestmark = [pytest.mark.service, pytest.mark.docker, pytest.mark.integration]
+
+ORDERS_BASE_URL_ENV_VAR = "TRADEBOT_TEST_ORDERS_BASE_URL"
+
+
+@pytest.fixture
+def orders_base_url() -> str:
+    base_url = os.getenv(ORDERS_BASE_URL_ENV_VAR)
+    if not base_url:
+        pytest.skip(f"set {ORDERS_BASE_URL_ENV_VAR} to run orders service stack tests")
+    return base_url.rstrip("/")
+
+
+def test_orders_service_runs_simulator_backed_order_lifecycle(orders_base_url: str):
+    preview_request = demo_preview_order_request()
+
+    with httpx.Client(timeout=5) as client:
+        health_response = client.get(f"{orders_base_url}/health-check")
+        preview_response = client.post(
+            f"{orders_base_url}/api/v1/ETRADE/accounts/{ACCOUNT_ID}/orders/preview",
+            json=preview_request.model_dump(mode="json"),
+        )
+
+        assert preview_response.status_code == HttpStatusCode.OK
+        preview_body = preview_response.json()
+        place_request = PlaceOrderRequest(
+            order_metadata=preview_request.order_metadata,
+            preview_id=preview_body["preview_id"],
+            order=preview_request.order,
+        )
+        place_url = (
+            f"{orders_base_url}/api/v1/ETRADE/accounts/{ACCOUNT_ID}/orders/preview/"
+            f"{preview_body['preview_id']}"
+        )
+        place_response = client.post(
+            place_url,
+            json=place_request.model_dump(mode="json"),
+        )
+        get_response = client.get(
+            f"{orders_base_url}/api/v1/ETRADE/accounts/{ACCOUNT_ID}/orders/{ORDER_ID}"
+        )
+        cancel_response = client.delete(
+            f"{orders_base_url}/api/v1/ETRADE/accounts/{ACCOUNT_ID}/orders/{ORDER_ID}"
+        )
+
+    assert health_response.status_code == HttpStatusCode.OK
+    assert health_response.json() == "ORDERS Service Up"
+
+    assert preview_body["request_status"] == "SUCCESS"
+
+    assert place_response.status_code == HttpStatusCode.OK
+    assert place_response.json()["order_id"] == ORDER_ID
+
+    assert get_response.status_code == HttpStatusCode.OK
+    assert get_response.json()["placed_order"]["placed_order_details"]["status"] == "OPEN"
+
+    assert cancel_response.status_code == HttpStatusCode.OK
+    assert cancel_response.json()["order_id"] == ORDER_ID
+    assert cancel_response.json()["request_status"] == "SUCCESS"

--- a/tests/integration/docker/test_quotes_service_stack.py
+++ b/tests/integration/docker/test_quotes_service_stack.py
@@ -1,0 +1,34 @@
+import os
+
+import httpx
+import pytest
+
+
+pytestmark = [pytest.mark.service, pytest.mark.docker, pytest.mark.integration]
+
+QUOTES_BASE_URL_ENV_VAR = "TRADEBOT_TEST_QUOTES_BASE_URL"
+
+
+@pytest.fixture
+def quotes_base_url() -> str:
+    base_url = os.getenv(QUOTES_BASE_URL_ENV_VAR)
+    if not base_url:
+        pytest.skip(f"set {QUOTES_BASE_URL_ENV_VAR} to run quotes service stack tests")
+    return base_url.rstrip("/")
+
+
+def test_quotes_service_returns_simulator_backed_equity_quote(quotes_base_url: str):
+    with httpx.Client(timeout=5) as client:
+        health_response = client.get(f"{quotes_base_url}/health-check")
+        quote_response = client.get(f"{quotes_base_url}/api/v1/ETRADE/quotes/tradable/GE")
+
+    assert health_response.status_code == 200
+    assert health_response.json() == "QUOTES Service Up"
+
+    assert quote_response.status_code == 200
+    body = quote_response.json()
+    assert body["tradable"]["ticker"] == "GE"
+    assert body["current_price"]["bid"] == 100.0
+    assert body["current_price"]["ask"] == 101.0
+    assert body["current_price"]["mark"] == 100.5
+    assert body["volume"] == 1000


### PR DESCRIPTION
## Summary
- Add a simulator-backed Docker Compose stack for the E*Trade simulator plus quotes and orders services.
- Implement `nox -s docker_integration` to build the image, start Compose with health checks, run Docker integration tests, print Compose logs on failure, and keep the local stack available briefly for inspection.
- Add an orders Docker integration slice that previews, places, fetches, and cancels an order through the real orders service container against the simulator container.
- Keep demo credentials validated while allowing a configured long cache age for checked-in simulator credentials.
- Fix E*Trade GET calls that need explicit empty params with `rauth`.

## Tickets
- Linear: https://linear.app/fianchetto-labs/issue/FIA-149/add-simulator-backed-real-process-deployment-smoke-tests
- Linear: https://linear.app/fianchetto-labs/issue/FIA-155/add-simulator-backed-docker-integration-test-for-order-lifecycle
- Follow-up: https://linear.app/fianchetto-labs/issue/FIA-156/add-simulator-backed-docker-integration-test-for-moex-orchestration

## Verification
- `.venv/bin/python -m py_compile noxfile.py tests/integration/docker/test_orders_service_stack.py tests/integration/docker/test_quotes_service_stack.py` -> passed
- `.venv/bin/python -m pytest tests/integration/docker -q` -> 2 skipped without service URLs, as expected
- `TRADEBOT_INTEGRATION_RUN_ID=test-run TRADEBOT_INTEGRATION_STACK_TTL_SECONDS=1800 docker compose -f deploy/docker/docker-compose.integration.yml config --quiet` -> passed
- `TRADEBOT_RUN_SERVICE_TESTS=1 TRADEBOT_INTEGRATION_STACK_TTL_SECONDS=0 .venv/bin/python -m nox -s docker_integration` -> 2 Docker integration tests passed and stack was torn down immediately
- `TRADEBOT_RUN_SERVICE_TESTS=1 TRADEBOT_INTEGRATION_STACK_TTL_SECONDS=5 .venv/bin/python -m nox -s docker_integration` -> 2 Docker integration tests passed, containers remained visible, then label cleanup removed them
- `.venv/bin/python -m nox -s unit functional` -> unit: 180 passed, 19 deselected; functional: 17 passed, 182 deselected
- `git diff --check` -> passed

## Notes
- Smoke tests are startup/health probes; Docker integration tests exercise service-to-service behavior across real process/container/network boundaries.
- Local Docker integration runs now default to a 30-minute TTL for inspection. Set `TRADEBOT_INTEGRATION_STACK_TTL_SECONDS=0` for immediate cleanup. CI always tears the stack down immediately.
- FIA-156 remains the next slice for MOEX orchestration over the same simulator-backed Docker boundary.
