### PR TITLE
FIA-156: Add MOEX Docker integration slice

### DIFF
--- a/deploy/docker/docker-compose.integration.yml
+++ b/deploy/docker/docker-compose.integration.yml
@@ -77,6 +77,36 @@ services:
       retries: 20
       start_period: 5s
 
+  moex:
+    image: ${TRADEBOT_DOCKER_IMAGE:-tradebot:local}
+    command: python -m fianchetto_tradebot.server.moex.serving.moex_rest_service
+    labels: *tradebot-integration-labels
+    environment:
+      FIANCHETTO_TRADEBOT_STATE_DIR: /app/deploy/docker/demo-state
+      TRADEBOT_ETRADE_API_BASE_URL: http://etrade-simulator:8090
+      TRADEBOT_ETRADE_CACHE_MAX_AGE_SECONDS: "315360000"
+      TRADEBOT_HEALTHCHECK_PORT: "8082"
+      TRADEBOT_MOEX_SERVICE_ADAPTER_MODE: http
+      TRADEBOT_ORDERS_SERVICE_URL: http://orders:8080
+      TRADEBOT_QUOTES_SERVICE_URL: http://quotes:8081
+    ports:
+      - "127.0.0.1:18082:8082"
+    depends_on:
+      orders:
+        condition: service_healthy
+      quotes:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8082/health-check', timeout=2).read()"
+      interval: 2s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
 networks:
   default:
     labels: *tradebot-integration-labels

--- a/docs/docker-poc.md
+++ b/docs/docker-poc.md
@@ -4,10 +4,11 @@ FIA-133 introduces one reusable image for local container startup checks. The
 image can run each current REST service by selecting the Python module at
 container start.
 
-The first Compose-backed integration slices start the E*Trade simulator plus the
-quotes and orders services. TradeBot services reach the simulator through Docker
-service DNS, so this proves more than container startup: it proves endpoint
-configuration, service networking, and representative TradeBot HTTP routes.
+The Compose-backed integration slices start the E*Trade simulator plus the
+quotes, orders, and MOEX services. TradeBot services reach the simulator and
+each other through Docker service DNS, so this proves more than container
+startup: it proves endpoint configuration, service networking, and
+representative TradeBot HTTP routes.
 
 ## Build
 
@@ -86,6 +87,11 @@ docker run --rm \
   python -m fianchetto_tradebot.server.moex.serving.moex_rest_service
 ```
 
+The standalone MOEX command uses in-process orders and quotes adapters. The
+Compose-backed integration stack sets `TRADEBOT_MOEX_SERVICE_ADAPTER_MODE=http`
+plus `TRADEBOT_ORDERS_SERVICE_URL` and `TRADEBOT_QUOTES_SERVICE_URL` so MOEX
+talks to the orders and quotes containers over Docker DNS.
+
 Then verify health from the host:
 
 ```bash
@@ -116,5 +122,6 @@ docker compose -f deploy/docker/docker-compose.integration.yml up --detach --wai
 curl http://127.0.0.1:18090/health-check
 curl http://127.0.0.1:18080/health-check
 curl http://127.0.0.1:18081/api/v1/ETRADE/quotes/tradable/GE
+curl http://127.0.0.1:18082/health-check
 docker compose -f deploy/docker/docker-compose.integration.yml down --volumes
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -133,9 +133,11 @@ This builds the local image, starts the Compose stack, waits for health checks,
 runs Docker integration tests, and leaves the stack available for 30 minutes on
 local machines. The current slices verify host pytest -> TradeBot service
 container -> E*Trade simulator container -> TradeBot service container -> host
-assertion for quotes and orders. That catches broken Docker DNS, port mapping,
-service startup ordering, connector base URL configuration, request/response
-serialization, and order lifecycle behavior across a real HTTP/process boundary.
+assertion for quotes and orders. They also verify MOEX -> orders/quotes over
+Docker DNS for a representative managed-execution lifecycle. That catches
+broken Docker DNS, port mapping, service startup ordering, connector base URL
+configuration, request/response serialization, and order lifecycle behavior
+across a real HTTP/process boundary.
 
 Integration cleanup is intentionally automatic. Local runs schedule cleanup by
 run-specific Docker labels so an old cleanup task does not remove a newer run.

--- a/noxfile.py
+++ b/noxfile.py
@@ -341,6 +341,7 @@ def docker_integration(session: nox.Session) -> None:
             env={
                 **os.environ,
                 SERVICE_TEST_ENV_VAR: "1",
+                "TRADEBOT_TEST_MOEX_BASE_URL": "http://127.0.0.1:18082",
                 "TRADEBOT_TEST_ORDERS_BASE_URL": "http://127.0.0.1:18080",
                 "TRADEBOT_TEST_QUOTES_BASE_URL": "http://127.0.0.1:18081",
             },

--- a/src/fianchetto_tradebot/server/moex/serving/moex_rest_service.py
+++ b/src/fianchetto_tradebot/server/moex/serving/moex_rest_service.py
@@ -1,4 +1,6 @@
+import os
 from datetime import datetime
+from typing import Mapping
 
 from fastapi import FastAPI
 
@@ -20,10 +22,19 @@ from fianchetto_tradebot.common_models.managed_executions.list_managed_execution
     ListManagedExecutionsResponse
 from fianchetto_tradebot.server.common.api.moex.moex_service import MoexService
 from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
-from fianchetto_tradebot.server.common.service.adapters import build_local_service_adapters
+from fianchetto_tradebot.server.common.service.adapters import (
+    ServiceAdapters,
+    build_http_service_adapters,
+    build_local_service_adapters,
+    load_http_service_adapter_config,
+)
 from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
 from fianchetto_tradebot.server.common.service.rest_service import RestService, ETRADE_ONLY_BROKERAGE_CONFIG
 from fianchetto_tradebot.server.common.service.service_key import ServiceKey
+
+MOEX_SERVICE_ADAPTER_MODE_ENV_VAR = "TRADEBOT_MOEX_SERVICE_ADAPTER_MODE"
+LOCAL_SERVICE_ADAPTER_MODE = "local"
+HTTP_SERVICE_ADAPTER_MODE = "http"
 
 JAN_1_2024 = datetime(2024,1,1).date()
 DEFAULT_START_DATE = JAN_1_2024
@@ -60,10 +71,25 @@ class MoexRestService(RestService):
 
 
     def _setup_brokerage_services(self):
-        local_services = build_local_service_adapters(self.connectors)
-        self.order_services: dict[Brokerage, OrderServicePort] = local_services.order_services
-        self.quotes_services: dict[Brokerage, QuoteServicePort] = local_services.quote_services
+        service_adapters = self._build_service_adapters()
+        self.order_services: dict[Brokerage, OrderServicePort] = service_adapters.order_services
+        self.quotes_services: dict[Brokerage, QuoteServicePort] = service_adapters.quote_services
         self.moex_service = MoexService(self.quotes_services, self.order_services)
+
+    def _build_service_adapters(self, env: Mapping[str, str] | None = None) -> ServiceAdapters:
+        env = os.environ if env is None else env
+        adapter_mode = env.get(MOEX_SERVICE_ADAPTER_MODE_ENV_VAR, LOCAL_SERVICE_ADAPTER_MODE).strip().lower()
+        if adapter_mode == LOCAL_SERVICE_ADAPTER_MODE:
+            return build_local_service_adapters(self.connectors)
+        if adapter_mode == HTTP_SERVICE_ADAPTER_MODE:
+            return build_http_service_adapters(
+                self.connectors.keys(),
+                config=load_http_service_adapter_config(env),
+            )
+        raise ValueError(
+            f"{MOEX_SERVICE_ADAPTER_MODE_ENV_VAR} must be "
+            f"'{LOCAL_SERVICE_ADAPTER_MODE}' or '{HTTP_SERVICE_ADAPTER_MODE}'"
+        )
 
     def list_managed_executions(self, brokerage: str, account_id: str):
         # TODO - FIA-114:

--- a/src/fianchetto_tradebot/server/orders/managed_order_execution.py
+++ b/src/fianchetto_tradebot/server/orders/managed_order_execution.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Optional, Type
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, field_serializer, field_validator, model_validator
 
 from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
 from fianchetto_tradebot.common_models.managed_executions.moex_status import MoexStatus
@@ -45,6 +45,10 @@ class ManagedExecutionCreationParams(BaseModel):
             except KeyError:
                 raise ValueError(f"Unknown tactic class name: {value}")
         return value
+
+    @field_serializer("tactic")
+    def serialize_tactic(self, value: Type[ExecutionTactic]) -> str:
+        return value.__name__
 
     @staticmethod
     def _json_fallback(obj):
@@ -97,6 +101,10 @@ class ManagedExecution(BaseModel):
             except KeyError:
                 raise ValueError(f"Unknown tactic class name: {value}")
         return value
+
+    @field_serializer("tactic")
+    def serialize_tactic(self, value: Type[ExecutionTactic]) -> str:
+        return value.__name__
 
     @staticmethod
     def _json_fallback(obj):

--- a/tests/common/service/test_moex_rest_service_composition.py
+++ b/tests/common/service/test_moex_rest_service_composition.py
@@ -1,0 +1,76 @@
+from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.server.common.service.adapters import ServiceAdapters
+from fianchetto_tradebot.server.moex.serving import moex_rest_service
+from fianchetto_tradebot.server.moex.serving.moex_rest_service import (
+    HTTP_SERVICE_ADAPTER_MODE,
+    LOCAL_SERVICE_ADAPTER_MODE,
+    MOEX_SERVICE_ADAPTER_MODE_ENV_VAR,
+    MoexRestService,
+)
+
+
+class _FakeConnector:
+    pass
+
+
+def test_moex_service_uses_local_adapters_by_default(monkeypatch):
+    service = object.__new__(MoexRestService)
+    service.connectors = {Brokerage.ETRADE: _FakeConnector()}
+    expected_adapters = ServiceAdapters(order_services={}, quote_services={})
+    calls = []
+
+    def build_local_service_adapters(connectors):
+        calls.append(connectors)
+        return expected_adapters
+
+    monkeypatch.setattr(
+        moex_rest_service,
+        "build_local_service_adapters",
+        build_local_service_adapters,
+    )
+
+    assert service._build_service_adapters(env={}) is expected_adapters
+    assert calls == [service.connectors]
+
+
+def test_moex_service_can_use_http_adapters_from_environment(monkeypatch):
+    service = object.__new__(MoexRestService)
+    service.connectors = {Brokerage.ETRADE: _FakeConnector()}
+    expected_adapters = ServiceAdapters(order_services={}, quote_services={})
+    calls = []
+    env = {
+        MOEX_SERVICE_ADAPTER_MODE_ENV_VAR: HTTP_SERVICE_ADAPTER_MODE,
+        "TRADEBOT_ORDERS_SERVICE_URL": "http://orders:8080",
+        "TRADEBOT_QUOTES_SERVICE_URL": "http://quotes:8081",
+    }
+
+    def build_http_service_adapters(brokerages, config):
+        calls.append((list(brokerages), config))
+        return expected_adapters
+
+    monkeypatch.setattr(
+        moex_rest_service,
+        "build_http_service_adapters",
+        build_http_service_adapters,
+    )
+
+    assert service._build_service_adapters(env=env) is expected_adapters
+
+    brokerages, config = calls[0]
+    assert brokerages == [Brokerage.ETRADE]
+    assert config.orders_base_url == "http://orders:8080"
+    assert config.quotes_base_url == "http://quotes:8081"
+
+
+def test_moex_service_rejects_unknown_adapter_mode():
+    service = object.__new__(MoexRestService)
+    service.connectors = {Brokerage.ETRADE: _FakeConnector()}
+
+    try:
+        service._build_service_adapters(env={MOEX_SERVICE_ADAPTER_MODE_ENV_VAR: "sideways"})
+    except ValueError as exc:
+        assert MOEX_SERVICE_ADAPTER_MODE_ENV_VAR in str(exc)
+        assert LOCAL_SERVICE_ADAPTER_MODE in str(exc)
+        assert HTTP_SERVICE_ADAPTER_MODE in str(exc)
+    else:
+        raise AssertionError("Expected unknown MOEX adapter mode to be rejected")

--- a/tests/integration/docker/test_moex_service_stack.py
+++ b/tests/integration/docker/test_moex_service_stack.py
@@ -1,0 +1,64 @@
+import os
+
+import httpx
+import pytest
+
+from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.common_models.managed_executions.create_managed_execution_request import (
+    CreateManagedExecutionRequest,
+)
+from fianchetto_tradebot.server.common.api.http_status_code import HttpStatusCode
+from fianchetto_tradebot.server.orders.managed_order_execution import (
+    ManagedExecutionCreationParams,
+    ManagedExecutionCreationType,
+)
+from tests.fixtures.etrade_simulator_contract import ACCOUNT_ID
+from tests.fixtures.etrade_simulator_contract import ORDER_ID
+from tests.fixtures.etrade_simulator_contract import demo_order
+
+
+pytestmark = [pytest.mark.service, pytest.mark.docker, pytest.mark.integration]
+
+MOEX_BASE_URL_ENV_VAR = "TRADEBOT_TEST_MOEX_BASE_URL"
+
+
+@pytest.fixture
+def moex_base_url() -> str:
+    base_url = os.getenv(MOEX_BASE_URL_ENV_VAR)
+    if not base_url:
+        pytest.skip(f"set {MOEX_BASE_URL_ENV_VAR} to run MOEX service stack tests")
+    return base_url.rstrip("/")
+
+
+def test_moex_service_runs_networked_managed_execution_lifecycle(moex_base_url: str):
+    request = CreateManagedExecutionRequest(
+        managed_execution_creation_params=ManagedExecutionCreationParams(
+            managed_execution_creation_type=ManagedExecutionCreationType.AS_NEW_ORDER,
+            brokerage=Brokerage.ETRADE,
+            account_id=ACCOUNT_ID,
+            creation_order=demo_order(),
+        )
+    )
+
+    with httpx.Client(timeout=20) as client:
+        health_response = client.get(f"{moex_base_url}/health-check")
+        create_response = client.post(
+            f"{moex_base_url}/api/v1/managed-executions",
+            json=request.model_dump(mode="json"),
+        )
+
+        assert create_response.status_code == HttpStatusCode.OK, create_response.text
+        managed_execution_id = create_response.json()["managed_execution_id"]
+        cancel_response = client.delete(
+            f"{moex_base_url}/api/v1/managed-executions/{managed_execution_id}"
+        )
+
+    assert health_response.status_code == HttpStatusCode.OK
+    assert health_response.json() == "MOEX Service Up"
+
+    assert managed_execution_id == "1"
+    assert cancel_response.status_code == HttpStatusCode.OK, cancel_response.text
+    body = cancel_response.json()
+    assert body["managed_execution"]["brokerage"] == "etrade"
+    assert body["managed_execution"]["account_id"] == ACCOUNT_ID
+    assert body["managed_execution"]["current_brokerage_order_id"] == ORDER_ID

--- a/tests/moex/serde/test_moex_req_res_serde.py
+++ b/tests/moex/serde/test_moex_req_res_serde.py
@@ -59,19 +59,13 @@ def test_managed_execution_dict_serde(managed_execution: ManagedExecution, accou
     assert reserialized.account_id == account_id
     assert reserialized.tactic == IncrementalPriceDeltaExecutionTactic
 
-def test_create_managed_execution_request_json_serde(managed_execution, account_id):
-    create_managed_execution_request: CreateManagedExecutionRequest = CreateManagedExecutionRequest(account_id=account_id, managed_execution=managed_execution)
+def test_managed_execution_json_mode_dump_serializes_tactic_name(managed_execution: ManagedExecution):
+    as_dict = managed_execution.model_dump(mode="json")
 
-    # serialize to json
-    as_json: str = create_managed_execution_request.model_dump_json()
+    assert as_dict["tactic"] == "IncrementalPriceDeltaExecutionTactic"
+    assert ManagedExecution.model_validate(as_dict).tactic == IncrementalPriceDeltaExecutionTactic
 
-    # deserialize from json
-    reserialized_from_json: ManagedExecution = CreateManagedExecutionRequest.model_validate_json(as_json)
-
-    assert reserialized_from_json.account_id == account_id
-    assert reserialized_from_json.managed_execution.tactic == IncrementalPriceDeltaExecutionTactic
-
-def test_create_managed_execution_request_json_serde(managed_execution, account_id, order):
+def test_create_managed_execution_request_with_creation_params_dict_serde(account_id, order):
     # TODO: Add more tests for the various other option types
     managed_execution_creation_params: ManagedExecutionCreationParams = ManagedExecutionCreationParams(managed_execution_creation_type=ManagedExecutionCreationType.AS_NEW_ORDER, brokerage=Brokerage.ETRADE, account_id=account_id, creation_order=order)
     create_managed_execution_request: CreateManagedExecutionRequest = CreateManagedExecutionRequest(managed_execution_creation_params=managed_execution_creation_params)
@@ -84,6 +78,25 @@ def test_create_managed_execution_request_json_serde(managed_execution, account_
 
     assert reserialized_from_json.managed_execution_creation_params.account_id == account_id
     assert reserialized_from_json.managed_execution_creation_params.tactic == IncrementalPriceDeltaExecutionTactic
+
+def test_create_managed_execution_request_json_mode_dump_serializes_tactic_name(account_id, order):
+    managed_execution_creation_params = ManagedExecutionCreationParams(
+        managed_execution_creation_type=ManagedExecutionCreationType.AS_NEW_ORDER,
+        brokerage=Brokerage.ETRADE,
+        account_id=account_id,
+        creation_order=order,
+    )
+    create_managed_execution_request = CreateManagedExecutionRequest(
+        managed_execution_creation_params=managed_execution_creation_params
+    )
+
+    as_dict = create_managed_execution_request.model_dump(mode="json")
+
+    assert as_dict["managed_execution_creation_params"]["tactic"] == "IncrementalPriceDeltaExecutionTactic"
+    assert (
+        CreateManagedExecutionRequest.model_validate(as_dict).managed_execution_creation_params.tactic
+        == IncrementalPriceDeltaExecutionTactic
+    )
 
 def test_managed_execution_new_order_creation_request_from_string():
     input = '{"managed_execution_creation_type":"AS_NEW_ORDER","brokerage":"etrade","account_id":"ABC123","reserve_order_price":null,"tactic":"IncrementalPriceDeltaExecutionTactic","creation_order":{"expiry":{"expiry_date":null,"all_or_none":false},"order_lines":[{"tradable":{"__type__":"Equity","price":null,"ticker":"GE","company_name":null},"action":"BUY","quantity":1,"quantity_filled":-1}],"order_price":{"order_price_type":"LIMIT","price":{"whole":100,"part":1,"currency":"USD","negative":false}}},"creation_order_id":null}'


### PR DESCRIPTION
Linear: https://linear.app/fianchetto-labs/issue/FIA-156/add-simulator-backed-docker-integration-test-for-moex-orchestration

Summary:
- Add MOEX to the simulator-backed Docker Compose integration stack.
- Let MOEX choose local adapters by default and HTTP adapters via TRADEBOT_MOEX_SERVICE_ADAPTER_MODE=http for Docker service-to-service runs.
- Add a Docker integration test for a managed-execution create/cancel lifecycle through MOEX, orders, and the E*Trade simulator.
- Serialize managed-execution tactics as stable class-name strings for JSON-mode dumps/responses.
- Update Docker/testing docs for the MOEX integration slice.

Verification:
- .venv/bin/python -m pytest tests/moex/serde/test_moex_req_res_serde.py tests/common/service/test_moex_rest_service_composition.py -q
- .venv/bin/python -m nox -s unit functional
- TRADEBOT_RUN_SERVICE_TESTS=1 TRADEBOT_INTEGRATION_STACK_TTL_SECONDS=0 .venv/bin/python -m nox -s docker_integration
- git diff --check