### PR TITLE
FIA-136: Add local Docker runtime commands

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.14'
       - name: Install dependencies

--- a/deploy/docker/docker-compose.local.yml
+++ b/deploy/docker/docker-compose.local.yml
@@ -1,0 +1,110 @@
+name: tradebot-local
+
+x-tradebot-local-labels: &tradebot-local-labels
+  fianchetto.tradebot.kind: docker-local
+
+services:
+  tradebot-etrade-simulator:
+    image: ${TRADEBOT_DOCKER_IMAGE:-tradebot:local}
+    command: python -m fianchetto_tradebot.server.simulator.etrade
+    labels: *tradebot-local-labels
+    environment:
+      TRADEBOT_ETRADE_SIMULATOR_HOST: 0.0.0.0
+      TRADEBOT_ETRADE_SIMULATOR_PORT: "8090"
+      TRADEBOT_HEALTHCHECK_PORT: "8090"
+    ports:
+      - "127.0.0.1:18090:8090"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8090/health-check', timeout=2).read()"
+      interval: 2s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
+  tradebot-quotes:
+    image: ${TRADEBOT_DOCKER_IMAGE:-tradebot:local}
+    command: python -m fianchetto_tradebot.server.quotes.serving.quotes_rest_service
+    labels: *tradebot-local-labels
+    environment:
+      FIANCHETTO_TRADEBOT_STATE_DIR: /app/deploy/docker/demo-state
+      TRADEBOT_ETRADE_API_BASE_URL: http://tradebot-etrade-simulator:8090
+      TRADEBOT_ETRADE_CACHE_MAX_AGE_SECONDS: "315360000"
+      TRADEBOT_HEALTHCHECK_PORT: "8081"
+    ports:
+      - "127.0.0.1:18081:8081"
+    depends_on:
+      tradebot-etrade-simulator:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8081/health-check', timeout=2).read()"
+      interval: 2s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
+  tradebot-orders:
+    image: ${TRADEBOT_DOCKER_IMAGE:-tradebot:local}
+    command: python -m fianchetto_tradebot.server.orders.serving.orders_rest_service
+    labels: *tradebot-local-labels
+    environment:
+      FIANCHETTO_TRADEBOT_STATE_DIR: /app/deploy/docker/demo-state
+      TRADEBOT_ETRADE_API_BASE_URL: http://tradebot-etrade-simulator:8090
+      TRADEBOT_ETRADE_CACHE_MAX_AGE_SECONDS: "315360000"
+      TRADEBOT_HEALTHCHECK_PORT: "8080"
+    ports:
+      - "127.0.0.1:18080:8080"
+    depends_on:
+      tradebot-etrade-simulator:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/health-check', timeout=2).read()"
+      interval: 2s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
+  tradebot-moex:
+    image: ${TRADEBOT_DOCKER_IMAGE:-tradebot:local}
+    command: python -m fianchetto_tradebot.server.moex.serving.moex_rest_service
+    labels: *tradebot-local-labels
+    environment:
+      FIANCHETTO_TRADEBOT_STATE_DIR: /app/deploy/docker/demo-state
+      TRADEBOT_ETRADE_API_BASE_URL: http://tradebot-etrade-simulator:8090
+      TRADEBOT_ETRADE_CACHE_MAX_AGE_SECONDS: "315360000"
+      TRADEBOT_HEALTHCHECK_PORT: "8082"
+      TRADEBOT_MOEX_SERVICE_ADAPTER_MODE: http
+      TRADEBOT_ORDERS_SERVICE_URL: http://tradebot-orders:8080
+      TRADEBOT_QUOTES_SERVICE_URL: http://tradebot-quotes:8081
+    ports:
+      - "127.0.0.1:18082:8082"
+    depends_on:
+      tradebot-orders:
+        condition: service_healthy
+      tradebot-quotes:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8082/health-check', timeout=2).read()"
+      interval: 2s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
+networks:
+  default:
+    labels: *tradebot-local-labels

--- a/docs/docker-poc.md
+++ b/docs/docker-poc.md
@@ -100,28 +100,71 @@ curl http://127.0.0.1:8080/health-check
 
 Change the port to match the service under test.
 
-## Run The Simulator-Backed Stack
+## Run The Local Simulator-Backed Stack
 
-Use Nox for the automated Docker integration run:
+Use Nox for the local development stack:
+
+```bash
+python -m nox -s docker_up
+```
+
+That command builds `tradebot:local`, starts the Compose stack in
+`deploy/docker/docker-compose.local.yml`, waits for service health, and leaves
+the containers running until you stop them. This is the normal dogfooding loop
+for local distributed-mode development.
+
+The local Compose stack uses stable service names that mirror the future
+deployment topology:
+
+| Service | Internal name | Host port |
+| --- | --- | --- |
+| E*Trade simulator | `tradebot-etrade-simulator` | `18090` |
+| Orders | `tradebot-orders` | `18080` |
+| Quotes | `tradebot-quotes` | `18081` |
+| MOEX | `tradebot-moex` | `18082` |
+
+MOEX talks to orders and quotes through Docker DNS:
+
+```bash
+TRADEBOT_ORDERS_SERVICE_URL=http://tradebot-orders:8080
+TRADEBOT_QUOTES_SERVICE_URL=http://tradebot-quotes:8081
+```
+
+Run the local acceptance checks after the stack is up:
+
+```bash
+python -m nox -s docker_acceptance
+```
+
+To inspect the stack manually:
+
+```bash
+curl http://127.0.0.1:18090/health-check
+curl http://127.0.0.1:18080/health-check
+curl http://127.0.0.1:18081/api/v1/ETRADE/quotes/tradable/GE
+curl http://127.0.0.1:18082/health-check
+```
+
+Inspect logs:
+
+```bash
+python -m nox -s docker_logs
+python -m nox -s docker_logs -- tradebot-moex
+```
+
+Stop the stack:
+
+```bash
+python -m nox -s docker_down
+```
+
+Use the automated Docker integration session when you want a test-owned stack
+with cleanup behavior:
 
 ```bash
 TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_integration
 ```
 
-That command builds `tradebot:local`, starts the Compose stack in
-`deploy/docker/docker-compose.integration.yml`, waits for service health, runs
-the Docker integration tests, and leaves the stack available for 30 minutes on
-local machines. CI runs and local runs with
-`TRADEBOT_INTEGRATION_STACK_TTL_SECONDS=0` tear the stack down immediately.
-
-To inspect the stack manually:
-
-```bash
-docker build --build-arg PYTHON_VERSION=3.14 -t tradebot:local .
-docker compose -f deploy/docker/docker-compose.integration.yml up --detach --wait
-curl http://127.0.0.1:18090/health-check
-curl http://127.0.0.1:18080/health-check
-curl http://127.0.0.1:18081/api/v1/ETRADE/quotes/tradable/GE
-curl http://127.0.0.1:18082/health-check
-docker compose -f deploy/docker/docker-compose.integration.yml down --volumes
-```
+That command uses `deploy/docker/docker-compose.integration.yml`, runs the
+Docker integration tests, and cleans up according to
+`TRADEBOT_INTEGRATION_STACK_TTL_SECONDS`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -92,6 +92,46 @@ Build the local Docker image after the Docker POC is present:
 python -m nox -s docker_build
 ```
 
+Start the local simulator-backed Docker stack for manual dogfooding:
+
+```bash
+python -m nox -s docker_up
+```
+
+This builds `tradebot:local`, starts the E*Trade simulator, orders, quotes, and
+MOEX services through `deploy/docker/docker-compose.local.yml`, waits for
+health checks, and leaves the containers running. The local stack uses stable
+Compose service names:
+
+| Service | Internal name | Host URL |
+| --- | --- | --- |
+| E*Trade simulator | `tradebot-etrade-simulator` | `http://127.0.0.1:18090` |
+| Orders | `tradebot-orders` | `http://127.0.0.1:18080` |
+| Quotes | `tradebot-quotes` | `http://127.0.0.1:18081` |
+| MOEX | `tradebot-moex` | `http://127.0.0.1:18082` |
+
+Run acceptance checks against the already-running local stack:
+
+```bash
+python -m nox -s docker_acceptance
+```
+
+This reuses the Docker integration tests as an explicit local acceptance pass.
+It does not start or stop containers; run `docker_up` first.
+
+Inspect logs:
+
+```bash
+python -m nox -s docker_logs
+python -m nox -s docker_logs -- tradebot-moex
+```
+
+Stop the local stack:
+
+```bash
+python -m nox -s docker_down
+```
+
 Run Docker-backed service smoke checks intentionally:
 
 ```bash
@@ -154,6 +194,10 @@ To clean the integration stack up early:
 ```bash
 docker compose -f deploy/docker/docker-compose.integration.yml down --volumes --remove-orphans
 ```
+
+Use `docker_integration` for an automated test-owned stack with TTL cleanup.
+Use `docker_up` / `docker_down` when you want a stable local runtime to inspect
+manually.
 
 The live paper-account E*Trade session is reserved for FIA-153 and must remain
 separately gated:

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,6 +27,7 @@ INTEGRATION_STACK_TTL_ENV_VAR = "TRADEBOT_INTEGRATION_STACK_TTL_SECONDS"
 DEFAULT_INTEGRATION_STACK_TTL_SECONDS = 30 * 60
 REPO_ROOT = Path(__file__).parent
 DOCKER_INTEGRATION_COMPOSE_FILE = REPO_ROOT / "deploy" / "docker" / "docker-compose.integration.yml"
+DOCKER_LOCAL_COMPOSE_FILE = REPO_ROOT / "deploy" / "docker" / "docker-compose.local.yml"
 UNIT_PYTEST_MARKER_EXPR = "not functional and not contract and not service and not docker and not integration and not live_e2e"
 FUNCTIONAL_PYTEST_MARKER_EXPR = "functional and not service and not docker and not integration and not live_e2e"
 
@@ -110,12 +111,17 @@ def _run_docker_command(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _run_docker_compose(session: nox.Session, *args: str, env: dict[str, str] | None = None) -> None:
+def _run_docker_compose(
+    session: nox.Session,
+    compose_file: Path,
+    *args: str,
+    env: dict[str, str] | None = None,
+) -> None:
     session.run(
         "docker",
         "compose",
         "-f",
-        str(DOCKER_INTEGRATION_COMPOSE_FILE),
+        str(compose_file),
         *args,
         external=True,
         env=env or {**os.environ, "TRADEBOT_DOCKER_IMAGE": DOCKER_IMAGE},
@@ -264,6 +270,74 @@ def _stop_smoke_service(service: DockerService) -> None:
     )
 
 
+@nox.session(python=False)
+def docker_up(session: nox.Session) -> None:
+    """Build the image and start the local simulator-backed service stack."""
+    _docker_build(session)
+    _run_docker_compose(
+        session,
+        DOCKER_LOCAL_COMPOSE_FILE,
+        "up",
+        "--detach",
+        "--wait",
+        "--force-recreate",
+        "--remove-orphans",
+    )
+    session.log("Local Docker stack is up.")
+    session.log("Simulator: http://127.0.0.1:18090/health-check")
+    session.log("Orders:    http://127.0.0.1:18080/health-check")
+    session.log("Quotes:    http://127.0.0.1:18081/health-check")
+    session.log("MOEX:      http://127.0.0.1:18082/health-check")
+
+
+@nox.session(python=False)
+def docker_down(session: nox.Session) -> None:
+    """Stop and remove the local simulator-backed service stack."""
+    _require_docker_available(session)
+    _run_docker_compose(
+        session,
+        DOCKER_LOCAL_COMPOSE_FILE,
+        "down",
+        "--volumes",
+        "--remove-orphans",
+    )
+
+
+@nox.session(python=False)
+def docker_logs(session: nox.Session) -> None:
+    """Show logs for the local simulator-backed service stack."""
+    _require_docker_available(session)
+    _run_docker_compose(
+        session,
+        DOCKER_LOCAL_COMPOSE_FILE,
+        "logs",
+        "--no-color",
+        *(session.posargs or []),
+    )
+
+
+@nox.session(python=PYTHON, venv_backend="venv", download_python="never")
+def docker_acceptance(session: nox.Session) -> None:
+    """Run Docker acceptance checks against the already-running local stack."""
+    _require_docker_available(session)
+    _install_project(session)
+    session.run(
+        "python",
+        "-m",
+        "pytest",
+        "-m",
+        "docker and integration",
+        "tests/integration/docker",
+        env={
+            **os.environ,
+            SERVICE_TEST_ENV_VAR: "1",
+            "TRADEBOT_TEST_MOEX_BASE_URL": "http://127.0.0.1:18082",
+            "TRADEBOT_TEST_ORDERS_BASE_URL": "http://127.0.0.1:18080",
+            "TRADEBOT_TEST_QUOTES_BASE_URL": "http://127.0.0.1:18081",
+        },
+    )
+
+
 @nox.session(python=PYTHON, venv_backend="venv", download_python="never")
 def unit(session: nox.Session) -> None:
     """Run the safe service-free test suite."""
@@ -329,8 +403,23 @@ def docker_integration(session: nox.Session) -> None:
     compose_env = _integration_compose_env(run_id, ttl_seconds)
 
     try:
-        _run_docker_compose(session, "down", "--volumes", "--remove-orphans", env=compose_env)
-        _run_docker_compose(session, "up", "--detach", "--wait", "--remove-orphans", env=compose_env)
+        _run_docker_compose(
+            session,
+            DOCKER_INTEGRATION_COMPOSE_FILE,
+            "down",
+            "--volumes",
+            "--remove-orphans",
+            env=compose_env,
+        )
+        _run_docker_compose(
+            session,
+            DOCKER_INTEGRATION_COMPOSE_FILE,
+            "up",
+            "--detach",
+            "--wait",
+            "--remove-orphans",
+            env=compose_env,
+        )
         session.run(
             "python",
             "-m",
@@ -347,7 +436,13 @@ def docker_integration(session: nox.Session) -> None:
             },
         )
     except Exception:
-        _run_docker_compose(session, "logs", "--no-color", env=compose_env)
+        _run_docker_compose(
+            session,
+            DOCKER_INTEGRATION_COMPOSE_FILE,
+            "logs",
+            "--no-color",
+            env=compose_env,
+        )
         raise
     finally:
         if ttl_seconds:
@@ -359,7 +454,14 @@ def docker_integration(session: nox.Session) -> None:
                 INTEGRATION_STACK_TTL_ENV_VAR,
             )
         else:
-            _run_docker_compose(session, "down", "--volumes", "--remove-orphans", env=compose_env)
+            _run_docker_compose(
+                session,
+                DOCKER_INTEGRATION_COMPOSE_FILE,
+                "down",
+                "--volumes",
+                "--remove-orphans",
+                env=compose_env,
+            )
 
 
 @nox.session(python=False)

--- a/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
+++ b/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
@@ -109,7 +109,7 @@ class ManagedExecutionWorker:
             get_order_response : GetOrderResponse = orders_service.get_order(get_order_request)
 
             current_status = get_order_response.placed_order.placed_order_details.status
-            self.moex.status = current_status
+            self.moex.status = MoexStatus(current_status.value)
             current_price = get_order_response.placed_order.placed_order_details.current_market_price
 
             order = get_order_response.placed_order.order
@@ -131,7 +131,7 @@ class ManagedExecutionWorker:
                 order_id = place_order_response.order_id
                 print(f"Successfully placed {place_order_response.order_id} for price {place_order_response.order.order_price}")
                 self.moex.current_brokerage_order_id = order_id
-                self.moex.status = OrderStatus.OPEN
+                self.moex.status = MoexStatus.OPEN
 
                 print(f"Sleeping {wait_time} seconds")
                 time.sleep(wait_time)
@@ -140,6 +140,7 @@ class ManagedExecutionWorker:
                 get_order_response : GetOrderResponse = orders_service.get_order(get_order_request)
 
                 current_status = get_order_response.placed_order.placed_order_details.status
+                self.moex.status = MoexStatus(current_status.value)
                 current_price = get_order_response.placed_order.order.order_price
 
             if not self.continue_processing:
@@ -258,6 +259,7 @@ class MoexService:
             if managed_execution.current_brokerage_order_id:
                 cancel_order_request: CancelOrderRequest = CancelOrderRequest(account_id=managed_execution.account_id, order_id=managed_execution.current_brokerage_order_id)
                 cancel_order_response: CancelOrderResponse = order_service.cancel_order(cancel_order_request)
+                managed_execution.status = MoexStatus.CANCELLED
                 print(f"Moex id: {managed_execution_id} - cancelled order {cancel_order_response.order_id} at {cancel_order_response.cancel_time}")
             else:
                 print(f"There is currently no open order for {managed_execution_id}, so nothing to cancel.")

--- a/tests/integration/docker/test_moex_service_stack.py
+++ b/tests/integration/docker/test_moex_service_stack.py
@@ -61,4 +61,5 @@ def test_moex_service_runs_networked_managed_execution_lifecycle(moex_base_url: 
     body = cancel_response.json()
     assert body["managed_execution"]["brokerage"] == "etrade"
     assert body["managed_execution"]["account_id"] == ACCOUNT_ID
+    assert body["managed_execution"]["status"] == "CANCELLED"
     assert body["managed_execution"]["current_brokerage_order_id"] == ORDER_ID

--- a/tests/moex/worker/eviction/test_moex_eviction.py
+++ b/tests/moex/worker/eviction/test_moex_eviction.py
@@ -128,6 +128,7 @@ def test_cancel_managed_execution_cancels_current_brokerage_order(
     expected_input_to_cancel_order = CancelOrderRequest(account_id=account_id, order_id=expected_order_id)
     mock_order_service.get_order.assert_called_once_with(GetOrderRequest(account_id=account_id, order_id=expected_order_id))
     mock_order_service.cancel_order.assert_called_once_with(expected_input_to_cancel_order)
+    assert cancel_managed_execution_response.managed_execution.status == MoexStatus.CANCELLED
     captured = capsys.readouterr()
     assert "Error occurred" not in captured.out
     assert captured.err == ""


### PR DESCRIPTION
Linear: https://linear.app/fianchetto-labs/issue/FIA-136/add-docker-compose-networking-for-tradebot-services

Summary:
- Add a local Docker Compose stack with stable tradebot-* service names for simulator, orders, quotes, and MOEX.
- Add Nox sessions for the local runtime loop: docker_up, docker_acceptance, docker_logs, and docker_down.
- Keep automated docker_integration separate from the manual dogfooding stack.
- Fix MOEX managed-execution status to remain MoexStatus at the model boundary, removing the Pydantic serialization warning seen in service logs.
- Update Docker/testing docs with the local runtime workflow.

Verification:
- .venv/bin/python -m py_compile noxfile.py src/fianchetto_tradebot/server/common/api/moex/moex_service.py
- docker compose -f deploy/docker/docker-compose.local.yml config --quiet
- docker compose -f deploy/docker/docker-compose.integration.yml config --quiet
- .venv/bin/python -m nox --list
- .venv/bin/python -m pytest tests/moex/worker/eviction/test_moex_eviction.py tests/moex/serde/test_moex_req_res_serde.py -q
- .venv/bin/python -m nox -s unit
- .venv/bin/python -m nox -s functional
- .venv/bin/python -m nox -s docker_up
- .venv/bin/python -m nox -s docker_acceptance
- .venv/bin/python -m nox -s docker_logs -- tradebot-moex, checked for no Pydantic warning / traceback / Error occurred
- .venv/bin/python -m nox -s docker_down
- TRADEBOT_RUN_SERVICE_TESTS=1 TRADEBOT_INTEGRATION_STACK_TTL_SECONDS=0 .venv/bin/python -m nox -s docker_integration
- git diff --check HEAD~1..HEAD

Notes:
- This intentionally stops at Docker Compose. Kubernetes/Helm remains FIA-137 scope.