### PR TITLE
FIA-136: Preserve terminal managed execution state

### DIFF
--- a/docs/managed-execution-status.md
+++ b/docs/managed-execution-status.md
@@ -46,6 +46,11 @@ Failure flow:
 2. `FAILED`: the worker errored, or the broker reported a terminal adverse
    status such as `EXPIRED` or `REJECTED` that the manager cannot continue from.
 
+Terminal managed executions are immutable through the cancellation API. Once a
+managed execution reaches `EXECUTED`, `CANCELLED`, or `FAILED`, a later cancel
+request must return the existing managed execution state without cancelling the
+underlying brokerage order or rewriting the managed execution status.
+
 ## Brokerage Status Translation
 
 When MOEX observes the current brokerage order, it records the raw brokerage
@@ -67,9 +72,10 @@ managed-execution lifecycle:
 
 Intentional managed cancellation is handled by the cancellation path:
 
-1. `cancel_managed_execution` asks the worker to stop, moving the managed execution to `CANCEL_REQUESTED`.
-2. The order service cancels the current brokerage order.
-3. The managed execution moves to `CANCELLED`.
+1. `cancel_managed_execution` confirms the managed execution is not already terminal.
+2. It asks the worker to stop, moving the managed execution to `CANCEL_REQUESTED`.
+3. The order service cancels the current brokerage order.
+4. The managed execution moves to `CANCELLED`.
 
 ## Creation Readiness
 

--- a/src/fianchetto_tradebot/common_models/managed_executions/managed_execution_status.py
+++ b/src/fianchetto_tradebot/common_models/managed_executions/managed_execution_status.py
@@ -12,6 +12,19 @@ class ManagedExecutionStatus(str, Enum):
     FAILED = "FAILED"
 
 
+TERMINAL_MANAGED_EXECUTION_STATUSES = frozenset(
+    {
+        ManagedExecutionStatus.CANCELLED,
+        ManagedExecutionStatus.EXECUTED,
+        ManagedExecutionStatus.FAILED,
+    }
+)
+
+
+def is_terminal_managed_execution_status(status: ManagedExecutionStatus) -> bool:
+    return status in TERMINAL_MANAGED_EXECUTION_STATUSES
+
+
 def managed_execution_status_from_order_status(order_status: OrderStatus) -> ManagedExecutionStatus:
     if order_status == OrderStatus.EXECUTED:
         return ManagedExecutionStatus.EXECUTED

--- a/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
+++ b/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
@@ -37,6 +37,7 @@ from fianchetto_tradebot.common_models.managed_executions.list_managed_execution
     ListManagedExecutionsResponse
 from fianchetto_tradebot.common_models.managed_executions.managed_execution_status import (
     ManagedExecutionStatus,
+    is_terminal_managed_execution_status,
     managed_execution_status_from_order_status,
 )
 from fianchetto_tradebot.common_models.order.action import Action
@@ -69,8 +70,9 @@ class ManagedExecutionWorker:
 
     def stop(self):
         print(f"Moex_id_thread {self.moex_id}: Received command to stop processing")
-        self.moex.status = ManagedExecutionStatus.CANCEL_REQUESTED
         self.continue_processing = False
+        if not is_terminal_managed_execution_status(self.moex.status):
+            self.moex.status = ManagedExecutionStatus.CANCEL_REQUESTED
 
     def __call__(self, *args, **kwargs):
         print(f"Executing order {self.moex_id}")
@@ -249,6 +251,9 @@ class MoexService:
         managed_execution_id: str = cancel_managed_executions_request.managed_execution_id
         with self.managed_executions_lock:
             managed_execution, worker, future = self.managed_executions[managed_execution_id]
+            if is_terminal_managed_execution_status(managed_execution.status):
+                print(f"Moex id: {managed_execution_id} already terminal with status {managed_execution.status}.")
+                return CancelManagedExecutionResponse(managed_execution=managed_execution)
 
             # Cancel the future first so it doesn't create a new order after-the-fact
             worker: ManagedExecutionWorker = worker

--- a/tests/common/test_managed_execution_status.py
+++ b/tests/common/test_managed_execution_status.py
@@ -1,7 +1,9 @@
 import pytest
 
 from fianchetto_tradebot.common_models.managed_executions.managed_execution_status import (
+    TERMINAL_MANAGED_EXECUTION_STATUSES,
     ManagedExecutionStatus,
+    is_terminal_managed_execution_status,
     managed_execution_status_from_order_status,
 )
 from fianchetto_tradebot.common_models.order.order_status import OrderStatus
@@ -42,3 +44,18 @@ def test_brokerage_cancellation_does_not_cancel_or_fail_the_managed_execution():
 def test_order_status_any_is_not_a_managed_execution_lifecycle_status():
     with pytest.raises(ValueError, match="query filter"):
         managed_execution_status_from_order_status(OrderStatus.ANY)
+
+
+def test_terminal_managed_execution_statuses_are_explicit():
+    assert TERMINAL_MANAGED_EXECUTION_STATUSES == {
+        ManagedExecutionStatus.CANCELLED,
+        ManagedExecutionStatus.EXECUTED,
+        ManagedExecutionStatus.FAILED,
+    }
+
+
+@pytest.mark.parametrize("status", ManagedExecutionStatus)
+def test_terminal_managed_execution_status_policy(status: ManagedExecutionStatus):
+    assert is_terminal_managed_execution_status(status) == (
+        status in TERMINAL_MANAGED_EXECUTION_STATUSES
+    )

--- a/tests/moex/worker/eviction/test_moex_eviction.py
+++ b/tests/moex/worker/eviction/test_moex_eviction.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from common.api.orders.order_test_util import OrderTestUtil
-from fianchetto_tradebot.common_models.api.orders.cancel_order_request import CancelOrderRequest
 from fianchetto_tradebot.common_models.api.orders.cancel_order_response import CancelOrderResponse
 from fianchetto_tradebot.common_models.api.orders.get_order_request import GetOrderRequest
 from fianchetto_tradebot.common_models.api.orders.get_order_response import GetOrderResponse
@@ -20,6 +19,10 @@ from fianchetto_tradebot.common_models.managed_executions.create_managed_executi
     CreateManagedExecutionRequest
 from fianchetto_tradebot.common_models.managed_executions.create_managed_execution_response import \
     CreateManagedExecutionResponse
+from fianchetto_tradebot.common_models.managed_executions.get_managed_execution_request import \
+    GetManagedExecutionRequest
+from fianchetto_tradebot.common_models.managed_executions.get_managed_execution_response import \
+    GetManagedExecutionResponse
 from fianchetto_tradebot.common_models.managed_executions.managed_execution_status import ManagedExecutionStatus
 from fianchetto_tradebot.common_models.order.order import Order
 from fianchetto_tradebot.common_models.order.order_status import OrderStatus
@@ -84,18 +87,54 @@ def test_all_managed_orders_closed_at_eod():
     pass
 
 @pytest.mark.functional
-def test_cancel_managed_execution_cancels_current_brokerage_order(
+def test_managed_execution_succeeds_when_brokerage_order_executes(
     account_id: str,
     order: Order,
     quotes_service_map: dict[Brokerage, QuotesService],
     orders_service_map: dict[Brokerage, OrderService],
     capsys: pytest.CaptureFixture,
 ):
-    # Given
-    # A user wants to cancel a managed execution.
-    # The user has cancelled their order using the API
-    # The request has been passed down into the MoexService
-    # 1. Assume the MOEX is running. There is exactly 1 managed execution in progress
+    mock_order_service = orders_service_map[Brokerage.ETRADE]
+    moex_service = MoexService(quotes_services=quotes_service_map, orders_services=orders_service_map)
+
+    managed_execution_creation_params = ManagedExecutionCreationParams(
+        managed_execution_creation_type=ManagedExecutionCreationType.AS_NEW_ORDER,
+        brokerage=Brokerage.ETRADE,
+        account_id=account_id,
+        creation_order=order,
+    )
+    create_managed_execution_request = CreateManagedExecutionRequest(
+        managed_execution_creation_params=managed_execution_creation_params
+    )
+    try:
+        create_managed_execution_response = moex_service.create_managed_execution(
+            create_managed_execution_request=create_managed_execution_request
+        )
+        get_managed_execution_response: GetManagedExecutionResponse = moex_service.get_managed_execution(
+            GetManagedExecutionRequest(
+                managed_execution_id=create_managed_execution_response.managed_execution_id
+            )
+        )
+    finally:
+        moex_service.thread_pool_executor.shutdown(wait=True)
+
+    managed_execution = get_managed_execution_response.managed_execution
+    assert managed_execution.status == ManagedExecutionStatus.EXECUTED
+    assert managed_execution.current_order_status == OrderStatus.EXECUTED
+    mock_order_service.cancel_order.assert_not_called()
+    captured = capsys.readouterr()
+    assert "Error occurred" not in captured.out
+    assert captured.err == ""
+
+
+@pytest.mark.functional
+def test_cancel_request_does_not_change_executed_managed_execution(
+    account_id: str,
+    order: Order,
+    quotes_service_map: dict[Brokerage, QuotesService],
+    orders_service_map: dict[Brokerage, OrderService],
+    capsys: pytest.CaptureFixture,
+):
     mock_order_service = orders_service_map[Brokerage.ETRADE]
     moex_service = MoexService(quotes_services=quotes_service_map, orders_services=orders_service_map)
 
@@ -107,8 +146,6 @@ def test_cancel_managed_execution_cancels_current_brokerage_order(
     try:
         create_managed_execution_response: CreateManagedExecutionResponse = moex_service.create_managed_execution(create_managed_execution_request=create_managed_execution_request)
 
-        # When
-        # We issue the MOEX cancellation order.
         moex_id = create_managed_execution_response.managed_execution_id
         cancel_managed_execution_request: CancelManagedExecutionRequest = CancelManagedExecutionRequest(managed_execution_id=moex_id)
         cancel_managed_execution_response: CancelManagedExecutionResponse = moex_service.cancel_managed_execution(cancel_managed_executions_request=cancel_managed_execution_request)
@@ -123,12 +160,9 @@ def test_cancel_managed_execution_cancels_current_brokerage_order(
         raise Exception(f"Could not get current_brokerage_order_id from"
                         f"cancel_managed_execution_response.managed_execution: {cancel_managed_execution_response.managed_execution.current_brokerage_order_id}")
 
-    # Then
-    # We see that the Brokerage Order is cancelled (using mocking).
-    expected_input_to_cancel_order = CancelOrderRequest(account_id=account_id, order_id=expected_order_id)
     mock_order_service.get_order.assert_called_once_with(GetOrderRequest(account_id=account_id, order_id=expected_order_id))
-    mock_order_service.cancel_order.assert_called_once_with(expected_input_to_cancel_order)
-    assert cancel_managed_execution_response.managed_execution.status == ManagedExecutionStatus.CANCELLED
+    mock_order_service.cancel_order.assert_not_called()
+    assert cancel_managed_execution_response.managed_execution.status == ManagedExecutionStatus.EXECUTED
     assert cancel_managed_execution_response.managed_execution.current_order_status == OrderStatus.EXECUTED
     captured = capsys.readouterr()
     assert "Error occurred" not in captured.out


### PR DESCRIPTION
Linear: https://linear.app/fianchetto-labs/issue/FIA-136/add-docker-compose-networking-for-tradebot-services

Summary:
- Treat EXECUTED, CANCELLED, and FAILED as terminal managed execution states.
- Make cancel_managed_execution return an already-terminal managed execution without rewriting its status or cancelling the underlying brokerage order.
- Add a functional success test showing a managed execution reaches EXECUTED when the broker order executes.
- Replace the contradictory cancel-after-executed test with a regression test proving executed managed executions remain EXECUTED.
- Document terminal-state immutability in the managed execution status guide.

Verification:
- .venv/bin/python -m pytest tests/common/test_managed_execution_status.py tests/moex/worker/eviction/test_moex_eviction.py -q
- .venv/bin/python -m py_compile src/fianchetto_tradebot/common_models/managed_executions/managed_execution_status.py src/fianchetto_tradebot/server/common/api/moex/moex_service.py
- git diff --cached --check
- .venv/bin/python -m nox -s functional
- .venv/bin/python -m nox -s unit