### PR TITLE
FIA-158: Add E*Trade simulator scenario controls

### DIFF
--- a/docs/etrade-simulator-contract.md
+++ b/docs/etrade-simulator-contract.md
@@ -44,6 +44,42 @@ The first simulator should support these E*Trade-like routes:
 | `GET` | `/v1/accounts/{account_id}/orders/{order_id}.json` | Return an open placed order. |
 | `PUT` | `/v1/accounts/{account_id}/orders/cancel.json` | Return a successful cancellation. |
 
+## Simulator Control Surface
+
+The simulator also exposes non-E*Trade control routes under `/_simulator`.
+These routes are for tests and local dogfooding only. Production TradeBot
+services should never call them.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/_simulator/reset` | Clear in-memory order state and restore the default `open` scenario. |
+| `POST` | `/_simulator/order-lifecycle-scenario` | Select how subsequent order status reads should progress. |
+
+Set a lifecycle scenario with:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"scenario":"eventually-executed"}' \
+  "http://127.0.0.1:8090/_simulator/order-lifecycle-scenario"
+```
+
+Supported order lifecycle scenarios:
+
+| Scenario | Behavior |
+| --- | --- |
+| `open` | Order reads remain `OPEN`. |
+| `eventually-executed` | First order read is `OPEN`; later reads are `EXECUTED`. |
+| `broker-cancelled` | First order read is `OPEN`; later reads are `CANCELLED`. |
+| `rejected` | Order reads are `REJECTED`. |
+
+An explicit cancel request still wins over scenario progression: after
+`PUT /v1/accounts/{account_id}/orders/cancel.json`, later reads return
+`CANCELLED`. Once an order reaches a terminal brokerage status such as
+`EXECUTED`, `CANCELLED`, or `REJECTED`, later scenario changes or cancel
+commands do not rewrite that order. Use `/_simulator/reset` to return to seed
+state.
+
 ## Failure Path
 
 The initial representative failure should be an order preview response with an

--- a/src/fianchetto_tradebot/server/simulator/etrade/etrade_simulator_app.py
+++ b/src/fianchetto_tradebot/server/simulator/etrade/etrade_simulator_app.py
@@ -1,28 +1,83 @@
 from dataclasses import dataclass, field
+from enum import Enum
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 
+from fianchetto_tradebot.common_models.order.order_status import OrderStatus
 from fianchetto_tradebot.server.common.api.http_status_code import HttpStatusCode
 from fianchetto_tradebot.server.simulator.etrade import seed_data
 
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8090
+TERMINAL_ORDER_STATUSES = {
+    OrderStatus.CANCELLED.value,
+    OrderStatus.EXECUTED.value,
+    OrderStatus.EXPIRED.value,
+    OrderStatus.REJECTED.value,
+}
+
+
+class OrderLifecycleScenario(str, Enum):
+    OPEN = "open"
+    EVENTUALLY_EXECUTED = "eventually-executed"
+    BROKER_CANCELLED = "broker-cancelled"
+    REJECTED = "rejected"
+
+
+class SimulatorScenarioRequest(BaseModel):
+    scenario: str
+
+
+class SimulatorScenarioResponse(BaseModel):
+    scenario: str
 
 
 @dataclass
 class ETradeSimulatorState:
     order_status_by_id: dict[str, str] = field(default_factory=dict)
+    order_read_count_by_id: dict[str, int] = field(default_factory=dict)
+    order_lifecycle_scenario: OrderLifecycleScenario = OrderLifecycleScenario.OPEN
 
     def place_order(self) -> str:
-        self.order_status_by_id[seed_data.ORDER_ID] = "OPEN"
+        self.order_status_by_id[seed_data.ORDER_ID] = OrderStatus.OPEN.value
+        self.order_read_count_by_id[seed_data.ORDER_ID] = 0
         return seed_data.ORDER_ID
 
     def get_order_status(self, order_id: str) -> str:
-        return self.order_status_by_id.get(order_id, "OPEN")
+        current_status = self.order_status_by_id.get(order_id, OrderStatus.OPEN.value)
+        if current_status in TERMINAL_ORDER_STATUSES:
+            return current_status
+
+        read_count = self.order_read_count_by_id.get(order_id, 0) + 1
+        self.order_read_count_by_id[order_id] = read_count
+        next_status = self._scenario_status_for_read(read_count)
+        self.order_status_by_id[order_id] = next_status
+        return next_status
 
     def cancel_order(self, order_id: str) -> None:
-        self.order_status_by_id[order_id] = "CANCELLED"
+        if self.order_status_by_id.get(order_id) in TERMINAL_ORDER_STATUSES:
+            return
+        self.order_status_by_id[order_id] = OrderStatus.CANCELLED.value
+
+    def reset(self) -> None:
+        self.order_status_by_id.clear()
+        self.order_read_count_by_id.clear()
+        self.order_lifecycle_scenario = OrderLifecycleScenario.OPEN
+
+    def set_order_lifecycle_scenario(self, scenario: OrderLifecycleScenario) -> None:
+        self.order_lifecycle_scenario = scenario
+        self.order_read_count_by_id.clear()
+
+    def _scenario_status_for_read(self, read_count: int) -> str:
+        if self.order_lifecycle_scenario == OrderLifecycleScenario.EVENTUALLY_EXECUTED and read_count >= 2:
+            return OrderStatus.EXECUTED.value
+        if self.order_lifecycle_scenario == OrderLifecycleScenario.BROKER_CANCELLED and read_count >= 2:
+            return OrderStatus.CANCELLED.value
+        if self.order_lifecycle_scenario == OrderLifecycleScenario.REJECTED:
+            return OrderStatus.REJECTED.value
+        return OrderStatus.OPEN.value
 
 
 def create_app(state: ETradeSimulatorState | None = None) -> FastAPI:
@@ -36,6 +91,17 @@ def create_app(state: ETradeSimulatorState | None = None) -> FastAPI:
     @app.get("/health-check")
     def health_check():
         return "E*Trade Simulator Up"
+
+    @app.post("/_simulator/reset")
+    def reset_simulator():
+        state.reset()
+        return SimulatorScenarioResponse(scenario=state.order_lifecycle_scenario.value)
+
+    @app.post("/_simulator/order-lifecycle-scenario")
+    def set_order_lifecycle_scenario(request: SimulatorScenarioRequest):
+        scenario = _order_lifecycle_scenario(request.scenario)
+        state.set_order_lifecycle_scenario(scenario)
+        return SimulatorScenarioResponse(scenario=scenario.value)
 
     @app.get("/v1/accounts/list.json")
     def list_accounts():
@@ -103,6 +169,17 @@ def _ensure_demo_account(account_id: str) -> None:
 def _ensure_supported_symbol(symbol: str) -> None:
     if symbol != seed_data.EQUITY_SYMBOL and not symbol.startswith(f"{seed_data.EQUITY_SYMBOL}:"):
         raise HTTPException(status_code=HttpStatusCode.NOT_FOUND, detail=f"Unknown simulator symbol {symbol}")
+
+
+def _order_lifecycle_scenario(scenario: str) -> OrderLifecycleScenario:
+    try:
+        return OrderLifecycleScenario(scenario)
+    except ValueError as exc:
+        supported_scenarios = ", ".join(item.value for item in OrderLifecycleScenario)
+        raise HTTPException(
+            status_code=HttpStatusCode.BAD_REQUEST,
+            detail=f"Unknown order lifecycle scenario {scenario}. Supported scenarios: {supported_scenarios}",
+        ) from exc
 
 
 app = create_app()

--- a/tests/common/api/etrade_simulator/test_etrade_simulator_app.py
+++ b/tests/common/api/etrade_simulator/test_etrade_simulator_app.py
@@ -7,6 +7,7 @@ from fianchetto_tradebot.common_models.finance.amount import Amount
 from fianchetto_tradebot.common_models.order.order_status import OrderStatus
 from fianchetto_tradebot.server.common.api.http_status_code import HttpStatusCode
 from fianchetto_tradebot.server.simulator.etrade import seed_data
+from fianchetto_tradebot.server.simulator.etrade.etrade_simulator_app import OrderLifecycleScenario
 from fianchetto_tradebot.server.simulator.etrade.etrade_simulator_app import create_app
 from tests.fixtures.etrade_simulator_scenario import ETradeSimulatorScenario
 
@@ -69,6 +70,126 @@ def test_etrade_simulator_supports_order_state_lifecycle():
     assert open_order.json()["OrdersResponse"]["Order"][0]["OrderDetail"][0]["status"] == "OPEN"
     assert canceled.json()["CancelOrderResponse"]["orderId"] == seed_data.ORDER_ID
     assert canceled_order.json()["OrdersResponse"]["Order"][0]["OrderDetail"][0]["status"] == "CANCELLED"
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_statuses"),
+    [
+        (OrderLifecycleScenario.OPEN, [OrderStatus.OPEN, OrderStatus.OPEN]),
+        (OrderLifecycleScenario.EVENTUALLY_EXECUTED, [OrderStatus.OPEN, OrderStatus.EXECUTED]),
+        (OrderLifecycleScenario.BROKER_CANCELLED, [OrderStatus.OPEN, OrderStatus.CANCELLED]),
+        (OrderLifecycleScenario.REJECTED, [OrderStatus.REJECTED, OrderStatus.REJECTED]),
+    ],
+)
+def test_etrade_simulator_order_lifecycle_scenarios_progress_by_read(scenario, expected_statuses):
+    # Given
+    # A simulator app with an explicit order lifecycle scenario selected.
+    client = TestClient(create_app())
+    scenario_response = client.post("/_simulator/order-lifecycle-scenario", json={"scenario": scenario.value})
+    client.post(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/place.json")
+
+    # When
+    # The caller polls the placed order.
+    observed_statuses = [
+        client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json").json()[
+            "OrdersResponse"
+        ]["Order"][0]["OrderDetail"][0]["status"]
+        for _ in expected_statuses
+    ]
+
+    # Then
+    # The scenario deterministically drives the brokerage-like order status.
+    assert scenario_response.status_code == HttpStatusCode.OK
+    assert scenario_response.json() == {"scenario": scenario.value}
+    assert observed_statuses == [status.value for status in expected_statuses]
+
+
+def test_etrade_simulator_reset_restores_open_order_scenario_and_seed_routes():
+    # Given
+    # A simulator app after a terminal scenario has advanced.
+    client = TestClient(create_app())
+    client.post(
+        "/_simulator/order-lifecycle-scenario",
+        json={"scenario": OrderLifecycleScenario.EVENTUALLY_EXECUTED.value},
+    )
+    client.post(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/place.json")
+    client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
+    executed_order = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
+
+    # When
+    # The simulator state is reset and a new seed order is placed.
+    reset_response = client.post("/_simulator/reset")
+    client.post(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/place.json")
+    reset_order = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
+
+    # Then
+    # The scenario returns to the default OPEN behavior without disturbing seed data routes.
+    assert executed_order.json()["OrdersResponse"]["Order"][0]["OrderDetail"][0]["status"] == OrderStatus.EXECUTED.value
+    assert reset_response.status_code == HttpStatusCode.OK
+    assert reset_response.json() == {"scenario": OrderLifecycleScenario.OPEN.value}
+    assert reset_order.json()["OrdersResponse"]["Order"][0]["OrderDetail"][0]["status"] == OrderStatus.OPEN.value
+    assert client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/balance.json").json()["BalanceResponse"]
+
+
+def test_etrade_simulator_rejects_unknown_order_lifecycle_scenario():
+    # Given
+    # A simulator app with a strict scenario control surface.
+    client = TestClient(create_app())
+
+    # When
+    # A caller requests an unsupported simulator scenario.
+    response = client.post("/_simulator/order-lifecycle-scenario", json={"scenario": "fills-by-moonlight"})
+
+    # Then
+    # The simulator fails clearly with the project's explicit bad-request status.
+    assert response.status_code == HttpStatusCode.BAD_REQUEST
+    assert "Supported scenarios" in response.json()["detail"]
+
+
+def test_etrade_simulator_explicit_cancel_wins_over_scenario_progression():
+    # Given
+    # A simulator app whose selected scenario would otherwise execute on the second read.
+    client = TestClient(create_app())
+    client.post(
+        "/_simulator/order-lifecycle-scenario",
+        json={"scenario": OrderLifecycleScenario.EVENTUALLY_EXECUTED.value},
+    )
+    client.post(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/place.json")
+
+    # When
+    # The caller actively cancels before polling the order through scenario progression.
+    client.put(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/cancel.json")
+    first_read = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
+    second_read = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
+
+    # Then
+    # The explicit cancellation remains the observed brokerage order state.
+    assert first_read.json()["OrdersResponse"]["Order"][0]["OrderDetail"][0]["status"] == OrderStatus.CANCELLED.value
+    assert second_read.json()["OrdersResponse"]["Order"][0]["OrderDetail"][0]["status"] == OrderStatus.CANCELLED.value
+
+
+def test_etrade_simulator_terminal_order_status_survives_later_commands():
+    # Given
+    # A simulator order that has already reached a terminal brokerage status.
+    client = TestClient(create_app())
+    client.post(
+        "/_simulator/order-lifecycle-scenario",
+        json={"scenario": OrderLifecycleScenario.EVENTUALLY_EXECUTED.value},
+    )
+    client.post(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/place.json")
+    client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
+    executed_order = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
+
+    # When
+    # Later simulator controls or cancel commands try to move it elsewhere.
+    client.post("/_simulator/order-lifecycle-scenario", json={"scenario": OrderLifecycleScenario.OPEN.value})
+    client.put(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/cancel.json")
+    final_order = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
+
+    # Then
+    # The terminal brokerage status remains terminal until simulator reset.
+    assert executed_order.json()["OrdersResponse"]["Order"][0]["OrderDetail"][0]["status"] == OrderStatus.EXECUTED.value
+    assert final_order.json()["OrdersResponse"]["Order"][0]["OrderDetail"][0]["status"] == OrderStatus.EXECUTED.value
 
 
 def test_etrade_simulator_exposes_retryable_preview_error_scenario():


### PR DESCRIPTION
## Summary
- add simulator-only `/_simulator` controls to reset state and select order lifecycle scenarios
- support deterministic `open`, `eventually-executed`, `broker-cancelled`, and `rejected` order status progression
- preserve terminal brokerage order states until simulator reset and document the control surface

## Linear
- https://linear.app/fianchetto-labs/issue/FIA-158/add-etrade-simulator-scenario-controls

## Verification
- `.venv/bin/python -m pytest tests/common/api/etrade_simulator/test_etrade_simulator_app.py tests/common/api/etrade_simulator/test_etrade_simulator_contract.py`
- `.venv/bin/python -m nox -s functional unit`

## Scope Notes
- This PR does not add Docker lifecycle tests. FIA-159 and FIA-160 will consume these simulator controls from the Docker integration stack.