### PR TITLE
FIA-159: Add Docker MOEX success scenario

### DIFF
--- a/docs/etrade-simulator-contract.md
+++ b/docs/etrade-simulator-contract.md
@@ -24,7 +24,7 @@ TradeBot needs in local Docker and future Kubernetes demos.
 - Equity: `GE`
 - Option: `GE 2026-01-16 PUT 25.00`
 - Preview id: `preview-1`
-- Placed order id: `order-1`
+- First placed order id: `order-1`
 - Response timestamp: `2026-01-02T13:30:00Z`
 
 ## Initial Endpoint Surface
@@ -40,7 +40,7 @@ The first simulator should support these E*Trade-like routes:
 | `GET` | `/v1/market/optionexpiredate.json` | Return deterministic option expiries for GE. |
 | `GET` | `/v1/market/optionchains.json` | Return a small call/put option chain for a requested expiry. |
 | `POST` | `/v1/accounts/{account_id}/orders/preview.json` | Return preview id `preview-1`. |
-| `POST` | `/v1/accounts/{account_id}/orders/place.json` | Return placed order id `order-1`. |
+| `POST` | `/v1/accounts/{account_id}/orders/place.json` | Return deterministic placed order ids starting with `order-1`. |
 | `GET` | `/v1/accounts/{account_id}/orders/{order_id}.json` | Return an open placed order. |
 | `PUT` | `/v1/accounts/{account_id}/orders/cancel.json` | Return a successful cancellation. |
 
@@ -69,8 +69,8 @@ Supported order lifecycle scenarios:
 | Scenario | Behavior |
 | --- | --- |
 | `open` | Order reads remain `OPEN`. |
-| `eventually-executed` | First order read is `OPEN`; later reads are `EXECUTED`. |
-| `broker-cancelled` | First order read is `OPEN`; later reads are `CANCELLED`. |
+| `eventually-executed` | First order read in the scenario is `OPEN`; later reads are `EXECUTED`. |
+| `broker-cancelled` | First order read in the scenario is `OPEN`; later reads are `CANCELLED`. |
 | `rejected` | Order reads are `REJECTED`. |
 
 An explicit cancel request still wins over scenario progression: after
@@ -79,6 +79,11 @@ An explicit cancel request still wins over scenario progression: after
 `EXECUTED`, `CANCELLED`, or `REJECTED`, later scenario changes or cancel
 commands do not rewrite that order. Use `/_simulator/reset` to return to seed
 state.
+
+The simulator assigns deterministic order ids in process memory: `order-1`,
+`order-2`, and so on. This lets managed-execution tests observe replacement
+orders without relying on a live broker. `/_simulator/reset` clears the order
+id sequence back to `order-1`.
 
 ## Failure Path
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -331,6 +331,7 @@ def docker_acceptance(session: nox.Session) -> None:
         env={
             **os.environ,
             SERVICE_TEST_ENV_VAR: "1",
+            "TRADEBOT_TEST_ETRADE_SIMULATOR_BASE_URL": "http://127.0.0.1:18090",
             "TRADEBOT_TEST_MOEX_BASE_URL": "http://127.0.0.1:18082",
             "TRADEBOT_TEST_ORDERS_BASE_URL": "http://127.0.0.1:18080",
             "TRADEBOT_TEST_QUOTES_BASE_URL": "http://127.0.0.1:18081",
@@ -430,6 +431,7 @@ def docker_integration(session: nox.Session) -> None:
             env={
                 **os.environ,
                 SERVICE_TEST_ENV_VAR: "1",
+                "TRADEBOT_TEST_ETRADE_SIMULATOR_BASE_URL": "http://127.0.0.1:18090",
                 "TRADEBOT_TEST_MOEX_BASE_URL": "http://127.0.0.1:18082",
                 "TRADEBOT_TEST_ORDERS_BASE_URL": "http://127.0.0.1:18080",
                 "TRADEBOT_TEST_QUOTES_BASE_URL": "http://127.0.0.1:18081",

--- a/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
+++ b/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
@@ -47,6 +47,8 @@ from fianchetto_tradebot.common_models.order.order_line import OrderLine
 from fianchetto_tradebot.common_models.order.order_price import OrderPrice
 from fianchetto_tradebot.common_models.order.order_price_type import OrderPriceType
 from fianchetto_tradebot.common_models.order.order_status import OrderStatus
+from fianchetto_tradebot.common_models.order.executed_order import ExecutedOrder
+from fianchetto_tradebot.common_models.order.placed_order import PlacedOrder
 from fianchetto_tradebot.server.common.api.http_status_code import HttpStatusCode
 from fianchetto_tradebot.server.common.api.orders.order_util import OrderUtil
 from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import ETradeConnector
@@ -103,17 +105,18 @@ class ManagedExecutionWorker:
             get_order_request = GetOrderRequest(account_id=account_id, order_id=order_id)
             get_order_response : GetOrderResponse = orders_service.get_order(get_order_request)
 
-            current_status = get_order_response.placed_order.placed_order_details.status
+            placed_order = _placed_order_snapshot_from_response(get_order_response)
+            current_status = placed_order.placed_order_details.status
             self.moex.current_order_status = current_status
             self.moex.status = managed_execution_status_from_order_status(current_status)
-            current_price = get_order_response.placed_order.placed_order_details.current_market_price
+            current_price = placed_order.placed_order_details.current_market_price
 
             if 'event_creation_lock' in kwargs:
                 event: threading.Event = kwargs['event_creation_lock']
                 print(f"Brokerage order {order_id} available for MOEX.")
                 event.set()
 
-            order = get_order_response.placed_order.order
+            order = placed_order.order
             if not order_metadata:
                 length = 15
                 characters = string.ascii_letters + string.digits
@@ -121,7 +124,7 @@ class ManagedExecutionWorker:
                 order_metadata: OrderMetadata = OrderMetadata(order_type=order.get_order_type(), account_id=account_id, client_order_id=new_client_order_id)
 
             while current_status != OrderStatus.EXECUTED and self.continue_processing:
-                new_price, wait_time = self.tactic.new_price(get_order_response.placed_order.order, quotes_service)
+                new_price, wait_time = self.tactic.new_price(placed_order.order, quotes_service)
 
                 # Need to populate this --
                 order.order_price = new_price
@@ -132,18 +135,25 @@ class ManagedExecutionWorker:
                 order_id = place_order_response.order_id
                 print(f"Successfully placed {place_order_response.order_id} for price {place_order_response.order.order_price}")
                 self.moex.current_brokerage_order_id = order_id
+                if not self.continue_processing:
+                    break
+
                 self.moex.status = ManagedExecutionStatus.WORKING
 
                 print(f"Sleeping {wait_time} seconds")
                 time.sleep(wait_time)
 
+                if not self.continue_processing:
+                    break
+
                 get_order_request = GetOrderRequest(account_id=account_id, order_id=order_id)
                 get_order_response : GetOrderResponse = orders_service.get_order(get_order_request)
 
-                current_status = get_order_response.placed_order.placed_order_details.status
+                placed_order = _placed_order_snapshot_from_response(get_order_response)
+                current_status = placed_order.placed_order_details.status
                 self.moex.current_order_status = current_status
                 self.moex.status = managed_execution_status_from_order_status(current_status)
-                current_price = get_order_response.placed_order.order.order_price
+                current_price = placed_order.order.order_price
 
             if not self.continue_processing:
                 print(f"Moex id {self.moex_id} cancelled with latest order-id {order_id} at price {current_price}!")
@@ -159,6 +169,14 @@ class ManagedExecutionWorker:
     def generate_random_alphanumeric(length=15):
         characters = string.ascii_letters + string.digits
         return ''.join(choice(characters) for _ in range(length))
+
+
+def _placed_order_snapshot_from_response(response: GetOrderResponse) -> PlacedOrder:
+    order_snapshot = response.placed_order
+    if isinstance(order_snapshot, ExecutedOrder):
+        return order_snapshot.order
+    return order_snapshot
+
 
 class MoexService:
     def __init__(self, quotes_services: dict[Brokerage, QuoteServicePort], orders_services: dict[Brokerage, OrderServicePort]):

--- a/src/fianchetto_tradebot/server/moex/serving/moex_rest_service.py
+++ b/src/fianchetto_tradebot/server/moex/serving/moex_rest_service.py
@@ -103,8 +103,7 @@ class MoexRestService(RestService):
 
     def get_managed_execution(self, managed_execution_id: str)->GetManagedExecutionResponse:
         get_managed_executions_request: GetManagedExecutionRequest = GetManagedExecutionRequest(managed_execution_id=managed_execution_id)
-        self.moex_service.get_managed_execution(get_managed_executions_request)
-        return GetManagedExecutionResponse()
+        return self.moex_service.get_managed_execution(get_managed_executions_request)
 
     def create_managed_execution(self, create_managed_execution_request: CreateManagedExecutionRequest):
         return self.moex_service.create_managed_execution(create_managed_execution_request=create_managed_execution_request)

--- a/src/fianchetto_tradebot/server/simulator/etrade/etrade_simulator_app.py
+++ b/src/fianchetto_tradebot/server/simulator/etrade/etrade_simulator_app.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass, field
 from enum import Enum
+from xml.etree import ElementTree
 
 import uvicorn
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel
 
 from fianchetto_tradebot.common_models.order.order_status import OrderStatus
@@ -39,20 +40,25 @@ class ETradeSimulatorState:
     order_status_by_id: dict[str, str] = field(default_factory=dict)
     order_read_count_by_id: dict[str, int] = field(default_factory=dict)
     order_lifecycle_scenario: OrderLifecycleScenario = OrderLifecycleScenario.OPEN
+    order_read_count: int = 0
+    next_order_number: int = 1
 
     def place_order(self) -> str:
-        self.order_status_by_id[seed_data.ORDER_ID] = OrderStatus.OPEN.value
-        self.order_read_count_by_id[seed_data.ORDER_ID] = 0
-        return seed_data.ORDER_ID
+        order_id = f"order-{self.next_order_number}"
+        self.next_order_number += 1
+        self.order_status_by_id[order_id] = OrderStatus.OPEN.value
+        self.order_read_count_by_id[order_id] = 0
+        return order_id
 
     def get_order_status(self, order_id: str) -> str:
         current_status = self.order_status_by_id.get(order_id, OrderStatus.OPEN.value)
         if current_status in TERMINAL_ORDER_STATUSES:
             return current_status
 
+        self.order_read_count += 1
         read_count = self.order_read_count_by_id.get(order_id, 0) + 1
         self.order_read_count_by_id[order_id] = read_count
-        next_status = self._scenario_status_for_read(read_count)
+        next_status = self._scenario_status_for_read()
         self.order_status_by_id[order_id] = next_status
         return next_status
 
@@ -65,15 +71,18 @@ class ETradeSimulatorState:
         self.order_status_by_id.clear()
         self.order_read_count_by_id.clear()
         self.order_lifecycle_scenario = OrderLifecycleScenario.OPEN
+        self.order_read_count = 0
+        self.next_order_number = 1
 
     def set_order_lifecycle_scenario(self, scenario: OrderLifecycleScenario) -> None:
         self.order_lifecycle_scenario = scenario
         self.order_read_count_by_id.clear()
+        self.order_read_count = 0
 
-    def _scenario_status_for_read(self, read_count: int) -> str:
-        if self.order_lifecycle_scenario == OrderLifecycleScenario.EVENTUALLY_EXECUTED and read_count >= 2:
+    def _scenario_status_for_read(self) -> str:
+        if self.order_lifecycle_scenario == OrderLifecycleScenario.EVENTUALLY_EXECUTED and self.order_read_count >= 2:
             return OrderStatus.EXECUTED.value
-        if self.order_lifecycle_scenario == OrderLifecycleScenario.BROKER_CANCELLED and read_count >= 2:
+        if self.order_lifecycle_scenario == OrderLifecycleScenario.BROKER_CANCELLED and self.order_read_count >= 2:
             return OrderStatus.CANCELLED.value
         if self.order_lifecycle_scenario == OrderLifecycleScenario.REJECTED:
             return OrderStatus.REJECTED.value
@@ -153,10 +162,11 @@ def create_app(state: ETradeSimulatorState | None = None) -> FastAPI:
         return seed_data.get_order_response(order_id, status=state.get_order_status(order_id))
 
     @app.put("/v1/accounts/{account_id}/orders/cancel.json")
-    def cancel_order(account_id: str):
+    async def cancel_order(account_id: str, request: Request):
         _ensure_demo_account(account_id)
-        state.cancel_order(seed_data.ORDER_ID)
-        return seed_data.cancel_order_response(seed_data.ORDER_ID)
+        order_id = _order_id_from_cancel_request(await request.body())
+        state.cancel_order(order_id)
+        return seed_data.cancel_order_response(order_id)
 
     return app
 
@@ -180,6 +190,30 @@ def _order_lifecycle_scenario(scenario: str) -> OrderLifecycleScenario:
             status_code=HttpStatusCode.BAD_REQUEST,
             detail=f"Unknown order lifecycle scenario {scenario}. Supported scenarios: {supported_scenarios}",
         ) from exc
+
+
+def _order_id_from_cancel_request(body: bytes) -> str:
+    if not body:
+        raise HTTPException(
+            status_code=HttpStatusCode.BAD_REQUEST,
+            detail="CancelOrderRequest XML body is required",
+        )
+
+    try:
+        root = ElementTree.fromstring(body)
+    except ElementTree.ParseError as exc:
+        raise HTTPException(
+            status_code=HttpStatusCode.BAD_REQUEST,
+            detail="CancelOrderRequest XML body must be valid XML",
+        ) from exc
+
+    order_id_element = root.find("orderId")
+    if order_id_element is None or not order_id_element.text:
+        raise HTTPException(
+            status_code=HttpStatusCode.BAD_REQUEST,
+            detail="CancelOrderRequest XML body must include orderId",
+        )
+    return order_id_element.text.strip()
 
 
 app = create_app()

--- a/src/fianchetto_tradebot/server/simulator/etrade/seed_data.py
+++ b/src/fianchetto_tradebot/server/simulator/etrade/seed_data.py
@@ -241,6 +241,11 @@ def etrade_order_json(status: str | None = None, include_market_values: bool = F
 
     if status:
         order["status"] = status
+    if status == "EXECUTED":
+        order["orderValue"] = 100.00
+        order["executedTime"] = 1767360660000
+        for instrument in order["Instrument"]:
+            instrument["filledQuantity"] = instrument["orderedQuantity"]
     if include_market_values:
         order.update(
             {

--- a/tests/common/api/etrade_simulator/test_etrade_simulator_app.py
+++ b/tests/common/api/etrade_simulator/test_etrade_simulator_app.py
@@ -14,6 +14,13 @@ from tests.fixtures.etrade_simulator_scenario import ETradeSimulatorScenario
 pytestmark = pytest.mark.functional
 
 
+def _cancel_order_xml(order_id: str) -> str:
+    return f"""
+        <CancelOrderRequest>
+          <orderId>{order_id}</orderId>
+        </CancelOrderRequest>"""
+
+
 def test_etrade_simulator_exposes_health_and_seed_routes():
     # Given
     # A simulator app running in-process.
@@ -60,7 +67,10 @@ def test_etrade_simulator_supports_order_state_lifecycle():
     preview = client.post(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/preview.json")
     placed = client.post(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/place.json")
     open_order = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
-    canceled = client.put(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/cancel.json")
+    canceled = client.put(
+        f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/cancel.json",
+        content=_cancel_order_xml(seed_data.ORDER_ID),
+    )
     canceled_order = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
 
     # Then
@@ -102,6 +112,39 @@ def test_etrade_simulator_order_lifecycle_scenarios_progress_by_read(scenario, e
     assert scenario_response.status_code == HttpStatusCode.OK
     assert scenario_response.json() == {"scenario": scenario.value}
     assert observed_statuses == [status.value for status in expected_statuses]
+
+
+def test_etrade_simulator_order_lifecycle_progresses_across_replacement_orders():
+    # Given
+    # A simulator scenario selected before an order is cancelled and replaced.
+    client = TestClient(create_app())
+    client.post(
+        "/_simulator/order-lifecycle-scenario",
+        json={"scenario": OrderLifecycleScenario.EVENTUALLY_EXECUTED.value},
+    )
+    first_placed = client.post(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/place.json")
+    first_order_id = first_placed.json()["PlaceOrderResponse"]["OrderIds"][0]["orderId"]
+    first_order = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{first_order_id}.json")
+    client.put(
+        f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/cancel.json",
+        content=_cancel_order_xml(first_order_id),
+    )
+
+    # When
+    # A replacement order is placed and read.
+    second_placed = client.post(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/place.json")
+    second_order_id = second_placed.json()["PlaceOrderResponse"]["OrderIds"][0]["orderId"]
+    second_order = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{second_order_id}.json")
+
+    # Then
+    # The simulator scenario can drive the replacement lifecycle a MOEX worker observes.
+    assert first_order_id == seed_data.ORDER_ID
+    assert second_order_id == "order-2"
+    assert first_order.json()["OrdersResponse"]["Order"][0]["OrderDetail"][0]["status"] == OrderStatus.OPEN.value
+    executed_order_detail = second_order.json()["OrdersResponse"]["Order"][0]["OrderDetail"][0]
+    assert executed_order_detail["status"] == OrderStatus.EXECUTED.value
+    assert executed_order_detail["orderValue"] == 100.00
+    assert executed_order_detail["executedTime"] == 1767360660000
 
 
 def test_etrade_simulator_reset_restores_open_order_scenario_and_seed_routes():
@@ -158,7 +201,10 @@ def test_etrade_simulator_explicit_cancel_wins_over_scenario_progression():
 
     # When
     # The caller actively cancels before polling the order through scenario progression.
-    client.put(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/cancel.json")
+    client.put(
+        f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/cancel.json",
+        content=_cancel_order_xml(seed_data.ORDER_ID),
+    )
     first_read = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
     second_read = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
 
@@ -183,13 +229,31 @@ def test_etrade_simulator_terminal_order_status_survives_later_commands():
     # When
     # Later simulator controls or cancel commands try to move it elsewhere.
     client.post("/_simulator/order-lifecycle-scenario", json={"scenario": OrderLifecycleScenario.OPEN.value})
-    client.put(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/cancel.json")
+    client.put(
+        f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/cancel.json",
+        content=_cancel_order_xml(seed_data.ORDER_ID),
+    )
     final_order = client.get(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/{seed_data.ORDER_ID}.json")
 
     # Then
     # The terminal brokerage status remains terminal until simulator reset.
     assert executed_order.json()["OrdersResponse"]["Order"][0]["OrderDetail"][0]["status"] == OrderStatus.EXECUTED.value
     assert final_order.json()["OrdersResponse"]["Order"][0]["OrderDetail"][0]["status"] == OrderStatus.EXECUTED.value
+
+
+def test_etrade_simulator_cancel_requires_order_id_xml_body():
+    # Given
+    # A simulator app with strict enough request validation to catch adapter regressions.
+    client = TestClient(create_app())
+
+    # When
+    # A caller attempts to cancel without the XML body the real E*Trade service sends.
+    response = client.put(f"/v1/accounts/{seed_data.ACCOUNT_ID}/orders/cancel.json")
+
+    # Then
+    # The simulator fails loudly instead of cancelling an unrelated seed order.
+    assert response.status_code == HttpStatusCode.BAD_REQUEST
+    assert "CancelOrderRequest XML body is required" in response.json()["detail"]
 
 
 def test_etrade_simulator_exposes_retryable_preview_error_scenario():

--- a/tests/common/service/test_moex_rest_service_composition.py
+++ b/tests/common/service/test_moex_rest_service_composition.py
@@ -1,4 +1,10 @@
 from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.common_models.managed_executions.get_managed_execution_request import (
+    GetManagedExecutionRequest,
+)
+from fianchetto_tradebot.common_models.managed_executions.get_managed_execution_response import (
+    GetManagedExecutionResponse,
+)
 from fianchetto_tradebot.server.common.service.adapters import ServiceAdapters
 from fianchetto_tradebot.server.moex.serving import moex_rest_service
 from fianchetto_tradebot.server.moex.serving.moex_rest_service import (
@@ -11,6 +17,16 @@ from fianchetto_tradebot.server.moex.serving.moex_rest_service import (
 
 class _FakeConnector:
     pass
+
+
+class _FakeMoexService:
+    def __init__(self, response):
+        self.response = response
+        self.requests = []
+
+    def get_managed_execution(self, request):
+        self.requests.append(request)
+        return self.response
 
 
 def test_moex_service_uses_local_adapters_by_default(monkeypatch):
@@ -74,3 +90,16 @@ def test_moex_service_rejects_unknown_adapter_mode():
         assert HTTP_SERVICE_ADAPTER_MODE in str(exc)
     else:
         raise AssertionError("Expected unknown MOEX adapter mode to be rejected")
+
+
+def test_moex_rest_get_managed_execution_returns_service_response():
+    service = object.__new__(MoexRestService)
+    expected_response = GetManagedExecutionResponse()
+    service.moex_service = _FakeMoexService(expected_response)
+
+    response = service.get_managed_execution("moex-1")
+
+    assert response is expected_response
+    assert service.moex_service.requests == [
+        GetManagedExecutionRequest(managed_execution_id="moex-1")
+    ]

--- a/tests/integration/docker/test_moex_service_stack.py
+++ b/tests/integration/docker/test_moex_service_stack.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import httpx
 import pytest
@@ -13,13 +14,21 @@ from fianchetto_tradebot.server.orders.managed_order_execution import (
     ManagedExecutionCreationType,
 )
 from tests.fixtures.etrade_simulator_contract import ACCOUNT_ID
-from tests.fixtures.etrade_simulator_contract import ORDER_ID
 from tests.fixtures.etrade_simulator_contract import demo_order
 
 
 pytestmark = [pytest.mark.service, pytest.mark.docker, pytest.mark.integration]
 
+ETRADE_SIMULATOR_BASE_URL_ENV_VAR = "TRADEBOT_TEST_ETRADE_SIMULATOR_BASE_URL"
 MOEX_BASE_URL_ENV_VAR = "TRADEBOT_TEST_MOEX_BASE_URL"
+
+
+@pytest.fixture
+def etrade_simulator_base_url() -> str:
+    base_url = os.getenv(ETRADE_SIMULATOR_BASE_URL_ENV_VAR)
+    if not base_url:
+        pytest.skip(f"set {ETRADE_SIMULATOR_BASE_URL_ENV_VAR} to run MOEX service stack tests")
+    return base_url.rstrip("/")
 
 
 @pytest.fixture
@@ -30,7 +39,10 @@ def moex_base_url() -> str:
     return base_url.rstrip("/")
 
 
-def test_moex_service_runs_networked_managed_execution_lifecycle(moex_base_url: str):
+def test_moex_service_runs_networked_managed_execution_lifecycle(
+    etrade_simulator_base_url: str,
+    moex_base_url: str,
+):
     request = CreateManagedExecutionRequest(
         managed_execution_creation_params=ManagedExecutionCreationParams(
             managed_execution_creation_type=ManagedExecutionCreationType.AS_NEW_ORDER,
@@ -41,6 +53,7 @@ def test_moex_service_runs_networked_managed_execution_lifecycle(moex_base_url: 
     )
 
     with httpx.Client(timeout=20) as client:
+        _reset_etrade_simulator(client, etrade_simulator_base_url)
         health_response = client.get(f"{moex_base_url}/health-check")
         create_response = client.post(
             f"{moex_base_url}/api/v1/managed-executions",
@@ -56,11 +69,96 @@ def test_moex_service_runs_networked_managed_execution_lifecycle(moex_base_url: 
     assert health_response.status_code == HttpStatusCode.OK
     assert health_response.json() == "MOEX Service Up"
 
-    assert managed_execution_id == "1"
+    assert managed_execution_id
     assert cancel_response.status_code == HttpStatusCode.OK, cancel_response.text
     body = cancel_response.json()
     assert body["managed_execution"]["brokerage"] == "etrade"
     assert body["managed_execution"]["account_id"] == ACCOUNT_ID
     assert body["managed_execution"]["status"] == "CANCELLED"
     assert body["managed_execution"]["current_order_status"] == "OPEN"
-    assert body["managed_execution"]["current_brokerage_order_id"] == ORDER_ID
+    assert body["managed_execution"]["current_brokerage_order_id"].startswith("order-")
+
+
+def test_moex_service_observes_networked_managed_execution_success(
+    etrade_simulator_base_url: str,
+    moex_base_url: str,
+):
+    request = CreateManagedExecutionRequest(
+        managed_execution_creation_params=ManagedExecutionCreationParams(
+            managed_execution_creation_type=ManagedExecutionCreationType.AS_NEW_ORDER,
+            brokerage=Brokerage.ETRADE,
+            account_id=ACCOUNT_ID,
+            creation_order=demo_order(),
+        )
+    )
+
+    with httpx.Client(timeout=20) as client:
+        _reset_etrade_simulator(client, etrade_simulator_base_url)
+        _set_etrade_order_lifecycle_scenario(
+            client,
+            etrade_simulator_base_url,
+            "eventually-executed",
+        )
+        create_response = client.post(
+            f"{moex_base_url}/api/v1/managed-executions",
+            json=request.model_dump(mode="json"),
+        )
+
+        assert create_response.status_code == HttpStatusCode.OK, create_response.text
+        managed_execution_id = create_response.json()["managed_execution_id"]
+        managed_execution = _wait_for_managed_execution_status(
+            client,
+            moex_base_url,
+            managed_execution_id,
+            expected_status="EXECUTED",
+        )
+
+    assert managed_execution["brokerage"] == "etrade"
+    assert managed_execution["account_id"] == ACCOUNT_ID
+    assert managed_execution["status"] == "EXECUTED"
+    assert managed_execution["current_order_status"] == "EXECUTED"
+    assert managed_execution["current_brokerage_order_id"].startswith("order-")
+
+
+def _reset_etrade_simulator(client: httpx.Client, etrade_simulator_base_url: str) -> None:
+    response = client.post(f"{etrade_simulator_base_url}/_simulator/reset")
+    assert response.status_code == HttpStatusCode.OK, response.text
+
+
+def _set_etrade_order_lifecycle_scenario(
+    client: httpx.Client,
+    etrade_simulator_base_url: str,
+    scenario: str,
+) -> None:
+    response = client.post(
+        f"{etrade_simulator_base_url}/_simulator/order-lifecycle-scenario",
+        json={"scenario": scenario},
+    )
+    assert response.status_code == HttpStatusCode.OK, response.text
+    assert response.json()["scenario"] == scenario
+
+
+def _wait_for_managed_execution_status(
+    client: httpx.Client,
+    moex_base_url: str,
+    managed_execution_id: str,
+    expected_status: str,
+    timeout_seconds: float = 20,
+) -> dict:
+    deadline = time.monotonic() + timeout_seconds
+    last_response_text = ""
+
+    while time.monotonic() < deadline:
+        response = client.get(f"{moex_base_url}/api/v1/managed-executions/{managed_execution_id}")
+        last_response_text = response.text
+        assert response.status_code == HttpStatusCode.OK, response.text
+
+        managed_execution = response.json()["managed_execution"]
+        if managed_execution["status"] == expected_status:
+            return managed_execution
+        time.sleep(0.25)
+
+    pytest.fail(
+        f"Managed execution {managed_execution_id} did not reach {expected_status} "
+        f"within {timeout_seconds} seconds. Last response: {last_response_text}"
+    )

--- a/tests/integration/docker/test_orders_service_stack.py
+++ b/tests/integration/docker/test_orders_service_stack.py
@@ -12,7 +12,16 @@ from tests.fixtures.etrade_simulator_contract import demo_preview_order_request
 
 pytestmark = [pytest.mark.service, pytest.mark.docker, pytest.mark.integration]
 
+ETRADE_SIMULATOR_BASE_URL_ENV_VAR = "TRADEBOT_TEST_ETRADE_SIMULATOR_BASE_URL"
 ORDERS_BASE_URL_ENV_VAR = "TRADEBOT_TEST_ORDERS_BASE_URL"
+
+
+@pytest.fixture
+def etrade_simulator_base_url() -> str:
+    base_url = os.getenv(ETRADE_SIMULATOR_BASE_URL_ENV_VAR)
+    if not base_url:
+        pytest.skip(f"set {ETRADE_SIMULATOR_BASE_URL_ENV_VAR} to run orders service stack tests")
+    return base_url.rstrip("/")
 
 
 @pytest.fixture
@@ -23,10 +32,14 @@ def orders_base_url() -> str:
     return base_url.rstrip("/")
 
 
-def test_orders_service_runs_simulator_backed_order_lifecycle(orders_base_url: str):
+def test_orders_service_runs_simulator_backed_order_lifecycle(
+    etrade_simulator_base_url: str,
+    orders_base_url: str,
+):
     preview_request = demo_preview_order_request()
 
     with httpx.Client(timeout=5) as client:
+        reset_response = client.post(f"{etrade_simulator_base_url}/_simulator/reset")
         health_response = client.get(f"{orders_base_url}/health-check")
         preview_response = client.post(
             f"{orders_base_url}/api/v1/ETRADE/accounts/{ACCOUNT_ID}/orders/preview",
@@ -54,6 +67,8 @@ def test_orders_service_runs_simulator_backed_order_lifecycle(orders_base_url: s
         cancel_response = client.delete(
             f"{orders_base_url}/api/v1/ETRADE/accounts/{ACCOUNT_ID}/orders/{ORDER_ID}"
         )
+
+    assert reset_response.status_code == HttpStatusCode.OK
 
     assert health_response.status_code == HttpStatusCode.OK
     assert health_response.json() == "ORDERS Service Up"

--- a/tests/moex/worker/eviction/test_moex_eviction.py
+++ b/tests/moex/worker/eviction/test_moex_eviction.py
@@ -10,6 +10,7 @@ from fianchetto_tradebot.common_models.api.orders.get_order_response import GetO
 from fianchetto_tradebot.common_models.api.orders.order_metadata import OrderMetadata
 from fianchetto_tradebot.common_models.api.orders.place_order_response import PlaceOrderResponse
 from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
+from fianchetto_tradebot.common_models.finance.amount import Amount
 from fianchetto_tradebot.common_models.finance.price import Price
 from fianchetto_tradebot.common_models.managed_executions.cancel_managed_execution_request import \
     CancelManagedExecutionRequest
@@ -25,6 +26,8 @@ from fianchetto_tradebot.common_models.managed_executions.get_managed_execution_
     GetManagedExecutionResponse
 from fianchetto_tradebot.common_models.managed_executions.managed_execution_status import ManagedExecutionStatus
 from fianchetto_tradebot.common_models.order.order import Order
+from fianchetto_tradebot.common_models.order.executed_order import ExecutedOrder
+from fianchetto_tradebot.common_models.order.executed_order_details import ExecutionOrderDetails
 from fianchetto_tradebot.common_models.order.order_status import OrderStatus
 from fianchetto_tradebot.common_models.order.order_type import OrderType
 from fianchetto_tradebot.common_models.order.placed_order import PlacedOrder
@@ -238,6 +241,69 @@ def test_cancel_request_does_not_change_executed_managed_execution(
     assert captured.err == ""
 
 
+@pytest.mark.functional
+def test_worker_stops_before_next_broker_poll_after_cancellation(
+    account_id: str,
+    order_id: str,
+    order: Order,
+    quotes_service_map: dict[Brokerage, QuotesService],
+    orders_service_map: dict[Brokerage, OrderService],
+    capsys: pytest.CaptureFixture,
+):
+    # Given
+    # A worker that has placed a replacement order and then receives a cancellation request.
+    replacement_order_id = "replacement_order_123"
+    managed_execution = ManagedExecution(
+        brokerage=Brokerage.ETRADE,
+        account_id=account_id,
+        original_order=order,
+        status=ManagedExecutionStatus.PRE_SUBMISSION,
+    )
+    worker = ManagedExecutionWorker(
+        moex=managed_execution,
+        moex_id="moex-1",
+        quotes_services=quotes_service_map,
+        orders_services=orders_service_map,
+    )
+    worker.tactic.new_price = MagicMock(return_value=(order.order_price, 0))
+
+    mock_order_service = orders_service_map[Brokerage.ETRADE]
+    mock_order_service.get_order = MagicMock(
+        return_value=_get_placed_order_response(
+            account_id=account_id,
+            order_id=order_id,
+            order=order,
+            status=OrderStatus.OPEN,
+        )
+    )
+
+    def cancel_after_replacement_order_is_placed(*args, **kwargs):
+        worker.stop()
+        return PlaceOrderResponse(
+            order_metadata=OrderMetadata(order_type=OrderType.SPREADS, account_id=account_id),
+            preview_id="replacement_preview_123",
+            order_id=replacement_order_id,
+            order=order,
+        )
+
+    mock_order_service.modify_order = MagicMock(side_effect=cancel_after_replacement_order_is_placed)
+
+    # When
+    # The cancellation arrives before the worker performs another broker read.
+    worker()
+
+    # Then
+    # The worker does not poll the broker again and leaves the managed execution cancelled.
+    mock_order_service.get_order.assert_called_once_with(
+        GetOrderRequest(account_id=account_id, order_id=order_id)
+    )
+    assert managed_execution.current_brokerage_order_id == replacement_order_id
+    assert managed_execution.status == ManagedExecutionStatus.CANCEL_REQUESTED
+    captured = capsys.readouterr()
+    assert "Error occurred" not in captured.out
+    assert captured.err == ""
+
+
 # TODO: Place into a separate class later
 def test_order_price_competitive():
     # TODO: implement this
@@ -253,13 +319,50 @@ def test_evicted_worker_no_longer_in_thread_pool():
 
 
 def _get_order_response(account_id: str, order_id: str, order: Order) -> GetOrderResponse:
+    placed_order = _placed_order(
+        account_id=account_id,
+        order_id=order_id,
+        order=order,
+        status=OrderStatus.EXECUTED,
+    )
+    return GetOrderResponse(
+        placed_order=ExecutedOrder(
+            order=placed_order,
+            execution_order_details=ExecutionOrderDetails(
+                order_value=Amount.from_float(100.0),
+                executed_time=datetime(2026, 7, 30, 12, 1, 0),
+            ),
+        )
+    )
+
+
+def _get_placed_order_response(
+    account_id: str,
+    order_id: str,
+    order: Order,
+    status: OrderStatus,
+) -> GetOrderResponse:
+    return GetOrderResponse(
+        placed_order=_placed_order(
+            account_id=account_id,
+            order_id=order_id,
+            order=order,
+            status=status,
+        )
+    )
+
+
+def _placed_order(
+    account_id: str,
+    order_id: str,
+    order: Order,
+    status: OrderStatus,
+) -> PlacedOrder:
     placed_order_details = PlacedOrderDetails(
         account_id=account_id,
         brokerage_order_id=order_id,
-        status=OrderStatus.EXECUTED,
+        status=status,
         order_placed_time=datetime(2026, 7, 30, 12, 0, 0),
         current_market_price=Price(bid=1.0, ask=1.2),
     )
-    return GetOrderResponse(
-        placed_order=PlacedOrder(order=order, placed_order_details=placed_order_details)
-    )
+    return PlacedOrder(order=order, placed_order_details=placed_order_details)


### PR DESCRIPTION
## Ticket

[FIA-159: Add Docker MOEX eventual-success integration scenario](https://linear.app/fianchetto-labs/issue/FIA-159/add-docker-moex-eventual-success-integration-scenario)

## Summary

- Add a Docker integration scenario where MOEX creates a managed execution, talks to the orders service, reaches the E*Trade simulator, and observes the managed execution reach EXECUTED.
- Extend the E*Trade simulator with deterministic replacement order ids, scenario progression across replacement orders, XML cancel-body validation, and executed-order payload fields.
- Fix MOEX service behavior uncovered by the scenario: REST get now returns the service response, workers handle ExecutedOrder snapshots, and cancellation no longer allows a worker to keep polling the broker afterward.

## Verification

- .venv/bin/python -m pytest tests/moex/worker/eviction/test_moex_eviction.py
- TRADEBOT_RUN_SERVICE_TESTS=1 .venv/bin/python -m nox -s docker_integration
- .venv/bin/python -m nox -s unit functional
- git diff --check
