### PR TITLE
FIA-168: Make managed execution waits cancellable

### DIFF
--- a/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
+++ b/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
@@ -68,11 +68,11 @@ class ManagedExecutionWorker:
         self.tactic: ExecutionTactic = moex.tactic
         self.quotes_services: dict[Brokerage, QuoteServicePort] = quotes_services
         self.orders_services: dict[Brokerage, OrderServicePort] = orders_services
-        self.continue_processing = True
+        self._stop_requested = threading.Event()
 
     def stop(self):
         print(f"Moex_id_thread {self.moex_id}: Received command to stop processing")
-        self.continue_processing = False
+        self._stop_requested.set()
         if not is_terminal_managed_execution_status(self.moex.status):
             self.moex.status = ManagedExecutionStatus.CANCEL_REQUESTED
 
@@ -123,7 +123,7 @@ class ManagedExecutionWorker:
                 new_client_order_id = ''.join(choice(characters) for _ in range(length))
                 order_metadata: OrderMetadata = OrderMetadata(order_type=order.get_order_type(), account_id=account_id, client_order_id=new_client_order_id)
 
-            while current_status != OrderStatus.EXECUTED and self.continue_processing:
+            while current_status != OrderStatus.EXECUTED and not self._stop_requested.is_set():
                 new_price, wait_time = self.tactic.new_price(placed_order.order, quotes_service)
 
                 # Need to populate this --
@@ -135,15 +135,13 @@ class ManagedExecutionWorker:
                 order_id = place_order_response.order_id
                 print(f"Successfully placed {place_order_response.order_id} for price {place_order_response.order.order_price}")
                 self.moex.current_brokerage_order_id = order_id
-                if not self.continue_processing:
+                if self._stop_requested.is_set():
                     break
 
                 self.moex.status = ManagedExecutionStatus.WORKING
 
                 print(f"Sleeping {wait_time} seconds")
-                time.sleep(wait_time)
-
-                if not self.continue_processing:
+                if self._stop_requested.wait(wait_time):
                     break
 
                 get_order_request = GetOrderRequest(account_id=account_id, order_id=order_id)
@@ -155,7 +153,7 @@ class ManagedExecutionWorker:
                 self.moex.status = managed_execution_status_from_order_status(current_status)
                 current_price = placed_order.order.order_price
 
-            if not self.continue_processing:
+            if self._stop_requested.is_set():
                 print(f"Moex id {self.moex_id} cancelled with latest order-id {order_id} at price {current_price}!")
             else:
                 print(f"Moex id {self.moex_id} executed with latest order-id {order_id} at price {current_price}!")

--- a/tests/moex/worker/eviction/test_moex_eviction.py
+++ b/tests/moex/worker/eviction/test_moex_eviction.py
@@ -1,3 +1,4 @@
+import threading
 from datetime import datetime
 from unittest.mock import MagicMock
 
@@ -297,6 +298,76 @@ def test_worker_stops_before_next_broker_poll_after_cancellation(
     mock_order_service.get_order.assert_called_once_with(
         GetOrderRequest(account_id=account_id, order_id=order_id)
     )
+    assert managed_execution.current_brokerage_order_id == replacement_order_id
+    assert managed_execution.status == ManagedExecutionStatus.CANCEL_REQUESTED
+    captured = capsys.readouterr()
+    assert "Error occurred" not in captured.out
+    assert captured.err == ""
+
+
+@pytest.mark.functional
+def test_worker_cancellation_interrupts_wait_before_next_broker_poll(
+    account_id: str,
+    order_id: str,
+    order: Order,
+    quotes_service_map: dict[Brokerage, QuotesService],
+    orders_service_map: dict[Brokerage, OrderService],
+    capsys: pytest.CaptureFixture,
+):
+    # Given
+    # A worker that would otherwise wait before checking a replacement order again.
+    replacement_order_id = "replacement_order_123"
+    managed_execution = ManagedExecution(
+        brokerage=Brokerage.ETRADE,
+        account_id=account_id,
+        original_order=order,
+        status=ManagedExecutionStatus.PRE_SUBMISSION,
+    )
+    worker = ManagedExecutionWorker(
+        moex=managed_execution,
+        moex_id="moex-1",
+        quotes_services=quotes_service_map,
+        orders_services=orders_service_map,
+    )
+    worker.tactic.new_price = MagicMock(return_value=(order.order_price, 60))
+
+    mock_order_service = orders_service_map[Brokerage.ETRADE]
+    mock_order_service.get_order = MagicMock(
+        return_value=_get_placed_order_response(
+            account_id=account_id,
+            order_id=order_id,
+            order=order,
+            status=OrderStatus.OPEN,
+        )
+    )
+    replacement_order_placed = threading.Event()
+
+    def mark_replacement_order_placed(*args, **kwargs):
+        replacement_order_placed.set()
+        return PlaceOrderResponse(
+            order_metadata=OrderMetadata(order_type=OrderType.SPREADS, account_id=account_id),
+            preview_id="replacement_preview_123",
+            order_id=replacement_order_id,
+            order=order,
+        )
+
+    mock_order_service.modify_order = MagicMock(side_effect=mark_replacement_order_placed)
+
+    # When
+    # Cancellation is requested while the worker is waiting before the next broker poll.
+    worker_thread = threading.Thread(target=worker)
+    worker_thread.start()
+    assert replacement_order_placed.wait(timeout=1)
+    worker.stop()
+    worker_thread.join(timeout=1)
+
+    # Then
+    # The worker wakes promptly and does not perform the follow-up broker poll.
+    assert not worker_thread.is_alive()
+    mock_order_service.get_order.assert_called_once_with(
+        GetOrderRequest(account_id=account_id, order_id=order_id)
+    )
+    mock_order_service.modify_order.assert_called_once()
     assert managed_execution.current_brokerage_order_id == replacement_order_id
     assert managed_execution.status == ManagedExecutionStatus.CANCEL_REQUESTED
     captured = capsys.readouterr()


### PR DESCRIPTION
## Ticket

[FIA-168: Replace blocking managed execution sleeps with cancellable waits](https://linear.app/fianchetto-labs/issue/FIA-168/replace-blocking-managed-execution-sleeps-with-cancellable-waits)

## Summary

- Replace the managed execution worker's boolean stop flag with a `threading.Event`.
- Use the stop event to interrupt the tactic wait before the next broker poll.
- Add a functional regression test proving cancellation wakes a waiting worker and prevents the follow-up broker read.

## Scope

This intentionally keeps the larger worker-step/state-machine refactor out of scope. It is the small FIA-168 slice: make the existing thread-based loop cooperatively cancellable without changing public MOEX behavior.

## Verification

- `.venv/bin/python -m pytest tests/moex/worker/eviction/test_moex_eviction.py` - 9 passed
- `.venv/bin/python -m nox -s functional` - 31 passed
- `.venv/bin/python -m nox -s unit` - 204 passed
- `TRADEBOT_RUN_SERVICE_TESTS=1 .venv/bin/python -m nox -s docker_integration` - 4 passed
- `git diff --check` - clean
