### PR TITLE
FIA-168: Clarify managed execution stop checks

### DIFF
--- a/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
+++ b/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
@@ -2,6 +2,7 @@ import string
 import threading
 import time
 from asyncio import Future
+from datetime import datetime
 from random import choice
 from threading import Lock
 from venv import create
@@ -13,6 +14,7 @@ from fianchetto_tradebot.common_models.api.orders.cancel_order_response import C
 from fianchetto_tradebot.common_models.api.orders.get_order_request import GetOrderRequest
 from fianchetto_tradebot.common_models.api.orders.get_order_response import GetOrderResponse
 from fianchetto_tradebot.common_models.api.orders.order_metadata import OrderMetadata
+from fianchetto_tradebot.common_models.api.orders.order_list_request import ListOrdersRequest
 from fianchetto_tradebot.common_models.api.orders.place_order_response import PlaceOrderResponse
 from fianchetto_tradebot.common_models.api.orders.preview_modify_order_request import PreviewModifyOrderRequest
 from fianchetto_tradebot.common_models.api.orders.preview_place_order_request import PreviewPlaceOrderRequest
@@ -76,6 +78,43 @@ class ManagedExecutionWorker:
         if not is_terminal_managed_execution_status(self.moex.status):
             self.moex.status = ManagedExecutionStatus.CANCEL_REQUESTED
 
+    def should_stop_processing(self) -> bool:
+        return self._stop_requested.is_set()
+
+    def should_continue_processing(self) -> bool:
+        return not self.should_stop_processing() and not is_terminal_managed_execution_status(self.moex.status)
+
+    def wait_before_next_order_status_check(self, wait_time: float) -> None:
+        self._stop_requested.wait(wait_time)
+
+    def record_order_snapshot(self, placed_order: PlacedOrder, orders_service: OrderServicePort) -> OrderStatus:
+        current_status = self.resolve_order_status(placed_order, orders_service)
+        self.moex.current_order_status = current_status
+        self.moex.status = managed_execution_status_from_order_status(current_status)
+        return current_status
+
+    def resolve_order_status(self, placed_order: PlacedOrder, orders_service: OrderServicePort) -> OrderStatus:
+        current_status = placed_order.placed_order_details.status
+        if current_status == OrderStatus.REJECTED and self.executed_order_exists_for(placed_order, orders_service):
+            return OrderStatus.EXECUTED
+        return current_status
+
+    def executed_order_exists_for(self, placed_order: PlacedOrder, orders_service: OrderServicePort) -> bool:
+        order_details = placed_order.placed_order_details
+        list_orders_response = orders_service.list_orders(
+            ListOrdersRequest(
+                account_id=order_details.account_id,
+                status=OrderStatus.EXECUTED,
+                from_date=order_details.order_placed_time,
+                to_date=max(datetime.now(), order_details.order_placed_time),
+                count=100,
+            )
+        )
+        return any(
+            _placed_order_snapshot(order).placed_order_details.brokerage_order_id == order_details.brokerage_order_id
+            for order in list_orders_response.order_list
+        )
+
     def __call__(self, *args, **kwargs):
         print(f"Executing order {self.moex_id}")
         orders_service = self.orders_services[self.moex.brokerage]
@@ -106,9 +145,7 @@ class ManagedExecutionWorker:
             get_order_response : GetOrderResponse = orders_service.get_order(get_order_request)
 
             placed_order = _placed_order_snapshot_from_response(get_order_response)
-            current_status = placed_order.placed_order_details.status
-            self.moex.current_order_status = current_status
-            self.moex.status = managed_execution_status_from_order_status(current_status)
+            current_status = self.record_order_snapshot(placed_order, orders_service)
             current_price = placed_order.placed_order_details.current_market_price
 
             if 'event_creation_lock' in kwargs:
@@ -123,7 +160,7 @@ class ManagedExecutionWorker:
                 new_client_order_id = ''.join(choice(characters) for _ in range(length))
                 order_metadata: OrderMetadata = OrderMetadata(order_type=order.get_order_type(), account_id=account_id, client_order_id=new_client_order_id)
 
-            while current_status != OrderStatus.EXECUTED and not self._stop_requested.is_set():
+            while self.should_continue_processing():
                 new_price, wait_time = self.tactic.new_price(placed_order.order, quotes_service)
 
                 # Need to populate this --
@@ -135,28 +172,27 @@ class ManagedExecutionWorker:
                 order_id = place_order_response.order_id
                 print(f"Successfully placed {place_order_response.order_id} for price {place_order_response.order.order_price}")
                 self.moex.current_brokerage_order_id = order_id
-                if self._stop_requested.is_set():
+                if self.should_stop_processing():
                     break
 
                 self.moex.status = ManagedExecutionStatus.WORKING
 
                 print(f"Sleeping {wait_time} seconds")
-                if self._stop_requested.wait(wait_time):
+                self.wait_before_next_order_status_check(wait_time)
+                if self.should_stop_processing():
                     break
 
                 get_order_request = GetOrderRequest(account_id=account_id, order_id=order_id)
                 get_order_response : GetOrderResponse = orders_service.get_order(get_order_request)
 
                 placed_order = _placed_order_snapshot_from_response(get_order_response)
-                current_status = placed_order.placed_order_details.status
-                self.moex.current_order_status = current_status
-                self.moex.status = managed_execution_status_from_order_status(current_status)
+                current_status = self.record_order_snapshot(placed_order, orders_service)
                 current_price = placed_order.order.order_price
 
-            if self._stop_requested.is_set():
+            if self.should_stop_processing():
                 print(f"Moex id {self.moex_id} cancelled with latest order-id {order_id} at price {current_price}!")
             else:
-                print(f"Moex id {self.moex_id} executed with latest order-id {order_id} at price {current_price}!")
+                print(f"Moex id {self.moex_id} completed with status {self.moex.status} for latest order-id {order_id} at price {current_price}!")
         except Exception as e:
             self.moex.status = ManagedExecutionStatus.FAILED
             print(f"Error occurred: {e}")
@@ -170,7 +206,10 @@ class ManagedExecutionWorker:
 
 
 def _placed_order_snapshot_from_response(response: GetOrderResponse) -> PlacedOrder:
-    order_snapshot = response.placed_order
+    return _placed_order_snapshot(response.placed_order)
+
+
+def _placed_order_snapshot(order_snapshot: PlacedOrder | ExecutedOrder) -> PlacedOrder:
     if isinstance(order_snapshot, ExecutedOrder):
         return order_snapshot.order
     return order_snapshot

--- a/src/fianchetto_tradebot/server/common/service/adapters/http_order_service_adapter.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/http_order_service_adapter.py
@@ -4,6 +4,8 @@ from fianchetto_tradebot.common_models.api.orders.cancel_order_request import Ca
 from fianchetto_tradebot.common_models.api.orders.cancel_order_response import CancelOrderResponse
 from fianchetto_tradebot.common_models.api.orders.get_order_request import GetOrderRequest
 from fianchetto_tradebot.common_models.api.orders.get_order_response import GetOrderResponse
+from fianchetto_tradebot.common_models.api.orders.order_list_request import ListOrdersRequest
+from fianchetto_tradebot.common_models.api.orders.order_list_response import ListOrdersResponse
 from fianchetto_tradebot.common_models.api.orders.place_order_response import PlaceOrderResponse
 from fianchetto_tradebot.common_models.api.orders.preview_modify_order_request import PreviewModifyOrderRequest
 from fianchetto_tradebot.common_models.api.orders.preview_order_request import PreviewOrderRequest
@@ -23,6 +25,19 @@ class HttpOrderServiceAdapter(HttpServiceAdapter, OrderServicePort):
             f"/api/v1/{self.brokerage.value}/accounts/{get_order_request.account_id}/orders/{get_order_request.order_id}",
         )
         return GetOrderResponse.model_validate(response.json())
+
+    def list_orders(self, list_orders_request: ListOrdersRequest) -> ListOrdersResponse:
+        response = self._request(
+            "GET",
+            f"/api/v1/{self.brokerage.value}/accounts/{list_orders_request.account_id}/orders",
+            params={
+                "status": list_orders_request.status.value,
+                "from_date": _iso_date(list_orders_request.from_date),
+                "to_date": _iso_date(list_orders_request.to_date),
+                "count": list_orders_request.count,
+            },
+        )
+        return ListOrdersResponse.model_validate(response.json())
 
     def cancel_order(self, cancel_order_request: CancelOrderRequest) -> CancelOrderResponse:
         response = self._request(
@@ -49,3 +64,9 @@ class HttpOrderServiceAdapter(HttpServiceAdapter, OrderServicePort):
             json=self._json_payload(preview_modify_order_request),
         )
         return PlaceOrderResponse.model_validate(response.json())
+
+
+def _iso_date(value) -> str:
+    if hasattr(value, "date"):
+        return value.date().isoformat()
+    return value.isoformat()

--- a/src/fianchetto_tradebot/server/common/service/adapters/local_order_service_adapter.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/local_order_service_adapter.py
@@ -2,6 +2,8 @@ from fianchetto_tradebot.common_models.api.orders.cancel_order_request import Ca
 from fianchetto_tradebot.common_models.api.orders.cancel_order_response import CancelOrderResponse
 from fianchetto_tradebot.common_models.api.orders.get_order_request import GetOrderRequest
 from fianchetto_tradebot.common_models.api.orders.get_order_response import GetOrderResponse
+from fianchetto_tradebot.common_models.api.orders.order_list_request import ListOrdersRequest
+from fianchetto_tradebot.common_models.api.orders.order_list_response import ListOrdersResponse
 from fianchetto_tradebot.common_models.api.orders.place_order_response import PlaceOrderResponse
 from fianchetto_tradebot.common_models.api.orders.preview_modify_order_request import PreviewModifyOrderRequest
 from fianchetto_tradebot.common_models.api.orders.preview_order_request import PreviewOrderRequest
@@ -14,6 +16,9 @@ class LocalOrderServiceAdapter(OrderServicePort):
 
     def get_order(self, get_order_request: GetOrderRequest) -> GetOrderResponse:
         return self.service.get_order(get_order_request)
+
+    def list_orders(self, list_orders_request: ListOrdersRequest) -> ListOrdersResponse:
+        return self.service.list_orders(list_orders_request)
 
     def cancel_order(self, cancel_order_request: CancelOrderRequest) -> CancelOrderResponse:
         return self.service.cancel_order(cancel_order_request)

--- a/src/fianchetto_tradebot/server/common/service/ports/order_service_port.py
+++ b/src/fianchetto_tradebot/server/common/service/ports/order_service_port.py
@@ -4,6 +4,8 @@ from fianchetto_tradebot.common_models.api.orders.cancel_order_request import Ca
 from fianchetto_tradebot.common_models.api.orders.cancel_order_response import CancelOrderResponse
 from fianchetto_tradebot.common_models.api.orders.get_order_request import GetOrderRequest
 from fianchetto_tradebot.common_models.api.orders.get_order_response import GetOrderResponse
+from fianchetto_tradebot.common_models.api.orders.order_list_request import ListOrdersRequest
+from fianchetto_tradebot.common_models.api.orders.order_list_response import ListOrdersResponse
 from fianchetto_tradebot.common_models.api.orders.place_order_response import PlaceOrderResponse
 from fianchetto_tradebot.common_models.api.orders.preview_modify_order_request import PreviewModifyOrderRequest
 from fianchetto_tradebot.common_models.api.orders.preview_order_request import PreviewOrderRequest
@@ -14,6 +16,9 @@ class OrderServicePort(Protocol):
     """Order dependency surface required by managed execution services."""
 
     def get_order(self, get_order_request: GetOrderRequest) -> GetOrderResponse:
+        ...
+
+    def list_orders(self, list_orders_request: ListOrdersRequest) -> ListOrdersResponse:
         ...
 
     def cancel_order(self, cancel_order_request: CancelOrderRequest) -> CancelOrderResponse:

--- a/src/fianchetto_tradebot/server/orders/serving/orders_rest_service.py
+++ b/src/fianchetto_tradebot/server/orders/serving/orders_rest_service.py
@@ -68,11 +68,13 @@ class OrdersRestService(RestService):
     def list_orders(self, brokerage: str, account_id: str, status: str = None, from_date: str=None, to_date: str=None, count:int=DEFAULT_COUNT):
         status = OrderStatus.ANY if not status else OrderStatus[status]
 
-        from_date = DEFAULT_START_DATE if not from_date else datetime.datetime.strptime(from_date, '%yyyy-mm-dd').date()
-        to_date = datetime.today().date() if not to_date else datetime.datetime.strptime(to_date, '%yyyy-mm-dd').date()
+        from_date = DEFAULT_START_DATE if not from_date else datetime.strptime(from_date, "%Y-%m-%d").date()
+        to_date = datetime.today().date() if not to_date else datetime.strptime(to_date, "%Y-%m-%d").date()
+        from_datetime = datetime.combine(from_date, datetime.min.time())
+        to_datetime = datetime.combine(to_date, datetime.min.time())
 
         order_service: OrderService = self.order_services[Brokerage[brokerage.upper()]]
-        list_order_request = ListOrdersRequest(account_id=account_id, status=status, from_date=from_date, to_date=to_date, count=count)
+        list_order_request = ListOrdersRequest(account_id=account_id, status=status, from_date=from_datetime, to_date=to_datetime, count=count)
 
         return order_service.list_orders(list_order_request)
 

--- a/tests/common/service/test_service_adapter_contracts.py
+++ b/tests/common/service/test_service_adapter_contracts.py
@@ -1,10 +1,11 @@
-from datetime import date
+from datetime import date, datetime
 
 import pytest
 from fastapi import FastAPI, HTTPException
 
 from fianchetto_tradebot.common_models.api.orders.cancel_order_request import CancelOrderRequest
 from fianchetto_tradebot.common_models.api.orders.get_order_request import GetOrderRequest
+from fianchetto_tradebot.common_models.api.orders.order_list_request import ListOrdersRequest
 from fianchetto_tradebot.common_models.api.quotes.get_tradable_request import GetTradableRequest
 from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
 from fianchetto_tradebot.common_models.finance.amount import Amount
@@ -12,6 +13,7 @@ from fianchetto_tradebot.common_models.finance.currency import Currency
 from fianchetto_tradebot.common_models.finance.equity import Equity
 from fianchetto_tradebot.common_models.finance.option import Option
 from fianchetto_tradebot.common_models.finance.option_type import OptionType
+from fianchetto_tradebot.common_models.order.order_status import OrderStatus
 from fianchetto_tradebot.server.common.service.adapters import (
     HttpQuoteServiceAdapter,
     HttpServiceAdapterError,
@@ -39,6 +41,14 @@ def test_order_adapter_contract_preserves_order_lifecycle(
     # When
     # The caller runs the order lifecycle through the adapter.
     place_response = order_adapter.preview_and_place_order(preview_request)
+    list_response = order_adapter.list_orders(
+        ListOrdersRequest(
+            account_id=ACCOUNT_ID,
+            status=OrderStatus.EXECUTED,
+            from_date=datetime(2026, 1, 1),
+            to_date=datetime(2026, 1, 2),
+        )
+    )
     get_response = order_adapter.get_order(GetOrderRequest(account_id=ACCOUNT_ID, order_id=place_response.order_id))
     modify_response = order_adapter.modify_order(preview_modify_order_request(place_response.order_id))
     cancel_response = order_adapter.cancel_order(
@@ -48,6 +58,7 @@ def test_order_adapter_contract_preserves_order_lifecycle(
     # Then
     # The caller receives the same domain responses regardless of adapter mode.
     assert place_response.order_id == INITIAL_ORDER_ID
+    assert list_response.order_list[0].placed_order_details.brokerage_order_id == INITIAL_ORDER_ID
     assert get_response.placed_order.placed_order_details.brokerage_order_id == INITIAL_ORDER_ID
     assert modify_response.order_id == MODIFIED_ORDER_ID
     assert cancel_response.order_id == MODIFIED_ORDER_ID
@@ -56,6 +67,14 @@ def test_order_adapter_contract_preserves_order_lifecycle(
     # The service behind the adapter receives rich Pydantic request models with the expected data.
     call_log = adapter_contract_harness.call_log
     assert call_log.preview_order_requests[0].order_metadata.account_id == ACCOUNT_ID
+    assert call_log.list_order_requests == [
+        ListOrdersRequest(
+            account_id=ACCOUNT_ID,
+            status=OrderStatus.EXECUTED,
+            from_date=datetime(2026, 1, 1),
+            to_date=datetime(2026, 1, 2),
+        )
+    ]
     assert call_log.preview_order_requests[0].order.order_lines[0].tradable.expiry == date(2025, 1, 31)
     assert call_log.get_order_requests == [GetOrderRequest(account_id=ACCOUNT_ID, order_id=INITIAL_ORDER_ID)]
     assert call_log.modify_order_requests[0].order_id_to_modify == INITIAL_ORDER_ID

--- a/tests/common/service/test_service_ports.py
+++ b/tests/common/service/test_service_ports.py
@@ -9,6 +9,9 @@ class FakeOrderService:
     def get_order(self, get_order_request):
         pass
 
+    def list_orders(self, list_orders_request):
+        pass
+
     def cancel_order(self, cancel_order_request):
         pass
 

--- a/tests/fixtures/service_adapter_contract.py
+++ b/tests/fixtures/service_adapter_contract.py
@@ -12,6 +12,8 @@ from fianchetto_tradebot.common_models.api.orders.cancel_order_request import Ca
 from fianchetto_tradebot.common_models.api.orders.cancel_order_response import CancelOrderResponse
 from fianchetto_tradebot.common_models.api.orders.get_order_request import GetOrderRequest
 from fianchetto_tradebot.common_models.api.orders.get_order_response import GetOrderResponse
+from fianchetto_tradebot.common_models.api.orders.order_list_request import ListOrdersRequest
+from fianchetto_tradebot.common_models.api.orders.order_list_response import ListOrdersResponse
 from fianchetto_tradebot.common_models.api.orders.order_metadata import OrderMetadata
 from fianchetto_tradebot.common_models.api.orders.place_order_response import PlaceOrderResponse
 from fianchetto_tradebot.common_models.api.orders.preview_modify_order_request import PreviewModifyOrderRequest
@@ -48,6 +50,7 @@ MODIFIED_ORDER_ID = "order-2"
 @dataclass
 class ContractCallLog:
     preview_order_requests: list[PreviewOrderRequest] = field(default_factory=list)
+    list_order_requests: list[ListOrdersRequest] = field(default_factory=list)
     modify_order_requests: list[PreviewModifyOrderRequest] = field(default_factory=list)
     get_order_requests: list[GetOrderRequest] = field(default_factory=list)
     cancel_order_requests: list[CancelOrderRequest] = field(default_factory=list)
@@ -80,6 +83,10 @@ class ContractOrderService(OrderServicePort):
     def get_order(self, get_order_request: GetOrderRequest) -> GetOrderResponse:
         self.call_log.get_order_requests.append(get_order_request)
         return get_order_response(get_order_request.order_id, OrderStatus.OPEN)
+
+    def list_orders(self, list_orders_request: ListOrdersRequest) -> ListOrdersResponse:
+        self.call_log.list_order_requests.append(list_orders_request)
+        return ListOrdersResponse(order_list=[get_order_response(INITIAL_ORDER_ID, OrderStatus.EXECUTED).placed_order])
 
     def modify_order(self, preview_modify_order_request: PreviewModifyOrderRequest) -> PlaceOrderResponse:
         self.call_log.modify_order_requests.append(preview_modify_order_request)
@@ -146,6 +153,26 @@ def adapter_contract_harness(request) -> AdapterContractHarness:
 
 def orders_app(order_service: OrderServicePort) -> FastAPI:
     app = FastAPI()
+
+    @app.get("/api/v1/{brokerage}/accounts/{account_id}/orders")
+    def _list_orders(
+        brokerage: str,
+        account_id: str,
+        status: OrderStatus,
+        from_date: date,
+        to_date: date,
+        count: int,
+    ):
+        assert Brokerage(brokerage) == Brokerage.ETRADE
+        return order_service.list_orders(
+            ListOrdersRequest(
+                account_id=account_id,
+                status=status,
+                from_date=datetime.combine(from_date, datetime.min.time()),
+                to_date=datetime.combine(to_date, datetime.min.time()),
+                count=count,
+            )
+        )
 
     @app.post("/api/v1/{brokerage}/accounts/{account_id}/orders/preview_and_place")
     def _preview_and_place_order(brokerage: str, account_id: str, preview_order_request: PreviewOrderRequest):

--- a/tests/moex/worker/eviction/test_moex_eviction.py
+++ b/tests/moex/worker/eviction/test_moex_eviction.py
@@ -8,6 +8,7 @@ from common.api.orders.order_test_util import OrderTestUtil
 from fianchetto_tradebot.common_models.api.orders.cancel_order_response import CancelOrderResponse
 from fianchetto_tradebot.common_models.api.orders.get_order_request import GetOrderRequest
 from fianchetto_tradebot.common_models.api.orders.get_order_response import GetOrderResponse
+from fianchetto_tradebot.common_models.api.orders.order_list_response import ListOrdersResponse
 from fianchetto_tradebot.common_models.api.orders.order_metadata import OrderMetadata
 from fianchetto_tradebot.common_models.api.orders.place_order_response import PlaceOrderResponse
 from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
@@ -74,6 +75,7 @@ def orders_service_map(account_id, order_id, order) -> dict[Brokerage, OrderServ
 
     mock_etrade_orders_service.preview_and_place_order = MagicMock(return_value=place_order_response)
     mock_etrade_orders_service.get_order = MagicMock(return_value=get_order_response)
+    mock_etrade_orders_service.list_orders = MagicMock(return_value=ListOrdersResponse(order_list=[]))
     mock_etrade_orders_service.cancel_order = MagicMock(return_value=cancel_order_response)
     order_service_map : dict[Brokerage, OrderService] = dict[Brokerage, OrderService]()
     order_service_map[Brokerage.ETRADE] = mock_etrade_orders_service
@@ -243,6 +245,119 @@ def test_cancel_request_does_not_change_executed_managed_execution(
 
 
 @pytest.mark.functional
+def test_worker_treats_rejected_order_as_executed_when_it_is_found_in_executed_orders(
+    account_id: str,
+    order_id: str,
+    order: Order,
+    quotes_service_map: dict[Brokerage, QuotesService],
+    orders_service_map: dict[Brokerage, OrderService],
+    capsys: pytest.CaptureFixture,
+):
+    # Given
+    # A brokerage order read that says rejected even though the same order is in the executed list.
+    managed_execution = ManagedExecution(
+        brokerage=Brokerage.ETRADE,
+        account_id=account_id,
+        original_order=order,
+        status=ManagedExecutionStatus.PRE_SUBMISSION,
+    )
+    worker = ManagedExecutionWorker(
+        moex=managed_execution,
+        moex_id="moex-1",
+        quotes_services=quotes_service_map,
+        orders_services=orders_service_map,
+    )
+    mock_order_service = orders_service_map[Brokerage.ETRADE]
+    mock_order_service.get_order = MagicMock(
+        return_value=_get_placed_order_response(
+            account_id=account_id,
+            order_id=order_id,
+            order=order,
+            status=OrderStatus.REJECTED,
+        )
+    )
+    mock_order_service.list_orders = MagicMock(
+        return_value=ListOrdersResponse(
+            order_list=[
+                _executed_order(
+                    account_id=account_id,
+                    order_id=order_id,
+                    order=order,
+                )
+            ]
+        )
+    )
+
+    # When
+    # The worker reconciles the rejected read against executed orders.
+    worker()
+
+    # Then
+    # The managed execution records the actual execution and does not reprice a terminal order.
+    mock_order_service.get_order.assert_called_once_with(
+        GetOrderRequest(account_id=account_id, order_id=order_id)
+    )
+    _assert_executed_orders_were_checked(mock_order_service, account_id)
+    mock_order_service.modify_order.assert_not_called()
+    assert managed_execution.status == ManagedExecutionStatus.EXECUTED
+    assert managed_execution.current_order_status == OrderStatus.EXECUTED
+    captured = capsys.readouterr()
+    assert "Error occurred" not in captured.out
+    assert captured.err == ""
+
+
+@pytest.mark.functional
+def test_worker_fails_rejected_order_when_it_is_not_found_in_executed_orders(
+    account_id: str,
+    order_id: str,
+    order: Order,
+    quotes_service_map: dict[Brokerage, QuotesService],
+    orders_service_map: dict[Brokerage, OrderService],
+    capsys: pytest.CaptureFixture,
+):
+    # Given
+    # A brokerage order that is rejected and absent from the executed order list.
+    managed_execution = ManagedExecution(
+        brokerage=Brokerage.ETRADE,
+        account_id=account_id,
+        original_order=order,
+        status=ManagedExecutionStatus.PRE_SUBMISSION,
+    )
+    worker = ManagedExecutionWorker(
+        moex=managed_execution,
+        moex_id="moex-1",
+        quotes_services=quotes_service_map,
+        orders_services=orders_service_map,
+    )
+    mock_order_service = orders_service_map[Brokerage.ETRADE]
+    mock_order_service.get_order = MagicMock(
+        return_value=_get_placed_order_response(
+            account_id=account_id,
+            order_id=order_id,
+            order=order,
+            status=OrderStatus.REJECTED,
+        )
+    )
+
+    # When
+    # The worker records the terminal brokerage status.
+    worker()
+
+    # Then
+    # The managed execution fails without trying to reprice or modify a terminal order.
+    mock_order_service.get_order.assert_called_once_with(
+        GetOrderRequest(account_id=account_id, order_id=order_id)
+    )
+    _assert_executed_orders_were_checked(mock_order_service, account_id)
+    mock_order_service.modify_order.assert_not_called()
+    assert managed_execution.status == ManagedExecutionStatus.FAILED
+    assert managed_execution.current_order_status == OrderStatus.REJECTED
+    captured = capsys.readouterr()
+    assert "Error occurred" not in captured.out
+    assert captured.err == ""
+
+
+@pytest.mark.functional
 def test_worker_stops_before_next_broker_poll_after_cancellation(
     account_id: str,
     order_id: str,
@@ -390,20 +505,8 @@ def test_evicted_worker_no_longer_in_thread_pool():
 
 
 def _get_order_response(account_id: str, order_id: str, order: Order) -> GetOrderResponse:
-    placed_order = _placed_order(
-        account_id=account_id,
-        order_id=order_id,
-        order=order,
-        status=OrderStatus.EXECUTED,
-    )
     return GetOrderResponse(
-        placed_order=ExecutedOrder(
-            order=placed_order,
-            execution_order_details=ExecutionOrderDetails(
-                order_value=Amount.from_float(100.0),
-                executed_time=datetime(2026, 7, 30, 12, 1, 0),
-            ),
-        )
+        placed_order=_executed_order(account_id=account_id, order_id=order_id, order=order)
     )
 
 
@@ -437,3 +540,20 @@ def _placed_order(
         current_market_price=Price(bid=1.0, ask=1.2),
     )
     return PlacedOrder(order=order, placed_order_details=placed_order_details)
+
+
+def _executed_order(account_id: str, order_id: str, order: Order) -> ExecutedOrder:
+    return ExecutedOrder(
+        order=_placed_order(account_id=account_id, order_id=order_id, order=order, status=OrderStatus.EXECUTED),
+        execution_order_details=ExecutionOrderDetails(
+            order_value=Amount.from_float(100.0),
+            executed_time=datetime(2026, 7, 30, 12, 1, 0),
+        ),
+    )
+
+
+def _assert_executed_orders_were_checked(mock_order_service: OrderService, account_id: str) -> None:
+    mock_order_service.list_orders.assert_called_once()
+    list_orders_request = mock_order_service.list_orders.call_args.args[0]
+    assert list_orders_request.account_id == account_id
+    assert list_orders_request.status == OrderStatus.EXECUTED


### PR DESCRIPTION
## Summary
- Add `ManagedExecutionWorker.should_stop_processing()` so loop decisions read as worker intent instead of raw threading-event checks.
- Add `ManagedExecutionWorker.should_continue_processing()` so the loop follows managed-execution terminal-state policy instead of hard-coding only `OrderStatus.EXECUTED`.
- Add `wait_before_next_order_status_check()` to keep the cancellable wait behind the worker boundary.
- Reconcile `REJECTED` brokerage reads against recent `EXECUTED` orders for the same brokerage order id, since E*Trade can report rejected after the order actually completed.
- Add `list_orders` to the order-service port and local/HTTP adapters so the reconciliation works in both in-process and service-to-service wiring.

## Ticket
- [FIA-168](https://linear.app/fianchetto-labs/issue/FIA-168/replace-blocking-managed-execution-sleeps-with-cancellable-waits)

## Notes
- Follow-up to #78, which merged before this readability cleanup landed on `main`.

## Verification
- `python -m pytest tests/moex/worker/eviction/test_moex_eviction.py` - 11 passed
- `python -m pytest tests/common/service/test_service_adapter_contracts.py tests/common/service/test_http_service_adapters.py` - 15 passed
- `python -m nox -s functional` - 33 passed
- `python -m nox -s unit` - 204 passed
- `TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_integration` - 4 passed
- `git diff --check origin/main..HEAD` - clean
