### PR TITLE
FIA-160: Cover MOEX cancellation Docker scenarios

### DIFF
--- a/tests/integration/docker/test_moex_service_stack.py
+++ b/tests/integration/docker/test_moex_service_stack.py
@@ -1,5 +1,6 @@
 import os
 import time
+from collections.abc import Callable
 
 import httpx
 import pytest
@@ -43,6 +44,8 @@ def test_moex_service_runs_networked_managed_execution_lifecycle(
     etrade_simulator_base_url: str,
     moex_base_url: str,
 ):
+    # Given
+    # A healthy Docker MOEX stack backed by the default open-order simulator scenario.
     request = CreateManagedExecutionRequest(
         managed_execution_creation_params=ManagedExecutionCreationParams(
             managed_execution_creation_type=ManagedExecutionCreationType.AS_NEW_ORDER,
@@ -55,6 +58,9 @@ def test_moex_service_runs_networked_managed_execution_lifecycle(
     with httpx.Client(timeout=20) as client:
         _reset_etrade_simulator(client, etrade_simulator_base_url)
         health_response = client.get(f"{moex_base_url}/health-check")
+
+        # When
+        # A managed execution is created and then explicitly cancelled by TradeBot.
         create_response = client.post(
             f"{moex_base_url}/api/v1/managed-executions",
             json=request.model_dump(mode="json"),
@@ -66,6 +72,8 @@ def test_moex_service_runs_networked_managed_execution_lifecycle(
             f"{moex_base_url}/api/v1/managed-executions/{managed_execution_id}"
         )
 
+    # Then
+    # The active cancellation path cancels the managed execution and preserves order state.
     assert health_response.status_code == HttpStatusCode.OK
     assert health_response.json() == "MOEX Service Up"
 
@@ -83,6 +91,8 @@ def test_moex_service_observes_networked_managed_execution_success(
     etrade_simulator_base_url: str,
     moex_base_url: str,
 ):
+    # Given
+    # A Docker MOEX stack whose simulator will eventually execute the brokerage order.
     request = CreateManagedExecutionRequest(
         managed_execution_creation_params=ManagedExecutionCreationParams(
             managed_execution_creation_type=ManagedExecutionCreationType.AS_NEW_ORDER,
@@ -99,6 +109,9 @@ def test_moex_service_observes_networked_managed_execution_success(
             etrade_simulator_base_url,
             "eventually-executed",
         )
+
+        # When
+        # A managed execution reaches EXECUTED and receives a later cancel request.
         create_response = client.post(
             f"{moex_base_url}/api/v1/managed-executions",
             json=request.model_dump(mode="json"),
@@ -112,12 +125,75 @@ def test_moex_service_observes_networked_managed_execution_success(
             managed_execution_id,
             expected_status="EXECUTED",
         )
+        cancel_response = client.delete(
+            f"{moex_base_url}/api/v1/managed-executions/{managed_execution_id}"
+        )
 
+    # Then
+    # The terminal managed execution state is not overwritten by the later command.
     assert managed_execution["brokerage"] == "etrade"
     assert managed_execution["account_id"] == ACCOUNT_ID
     assert managed_execution["status"] == "EXECUTED"
     assert managed_execution["current_order_status"] == "EXECUTED"
     assert managed_execution["current_brokerage_order_id"].startswith("order-")
+    assert cancel_response.status_code == HttpStatusCode.OK, cancel_response.text
+    assert cancel_response.json()["managed_execution"]["status"] == "EXECUTED"
+
+
+def test_moex_service_treats_broker_cancelled_order_as_transient_work(
+    etrade_simulator_base_url: str,
+    moex_base_url: str,
+):
+    # Given
+    # A Docker MOEX stack whose broker simulator cancels the underlying order.
+    request = CreateManagedExecutionRequest(
+        managed_execution_creation_params=ManagedExecutionCreationParams(
+            managed_execution_creation_type=ManagedExecutionCreationType.AS_NEW_ORDER,
+            brokerage=Brokerage.ETRADE,
+            account_id=ACCOUNT_ID,
+            creation_order=demo_order(),
+        )
+    )
+
+    with httpx.Client(timeout=20) as client:
+        _reset_etrade_simulator(client, etrade_simulator_base_url)
+        _set_etrade_order_lifecycle_scenario(
+            client,
+            etrade_simulator_base_url,
+            "broker-cancelled",
+        )
+
+        # When
+        # MOEX observes the broker-side cancellation and is later explicitly cancelled.
+        create_response = client.post(
+            f"{moex_base_url}/api/v1/managed-executions",
+            json=request.model_dump(mode="json"),
+        )
+
+        assert create_response.status_code == HttpStatusCode.OK, create_response.text
+        managed_execution_id = create_response.json()["managed_execution_id"]
+        working_after_broker_cancel = _wait_for_managed_execution(
+            client,
+            moex_base_url,
+            managed_execution_id,
+            lambda managed_execution: (
+                managed_execution["status"] == "WORKING"
+                and managed_execution["current_order_status"] == "CANCELLED"
+            ),
+            expected_description="WORKING with a broker-side CANCELLED order",
+        )
+        cancel_response = client.delete(
+            f"{moex_base_url}/api/v1/managed-executions/{managed_execution_id}"
+        )
+
+    # Then
+    # Broker-side cancellation is treated as transient work, not managed-execution failure.
+    assert working_after_broker_cancel["brokerage"] == "etrade"
+    assert working_after_broker_cancel["account_id"] == ACCOUNT_ID
+    assert working_after_broker_cancel["status"] == "WORKING"
+    assert working_after_broker_cancel["current_order_status"] == "CANCELLED"
+    assert cancel_response.status_code == HttpStatusCode.OK, cancel_response.text
+    assert cancel_response.json()["managed_execution"]["status"] == "CANCELLED"
 
 
 def _reset_etrade_simulator(client: httpx.Client, etrade_simulator_base_url: str) -> None:
@@ -145,6 +221,24 @@ def _wait_for_managed_execution_status(
     expected_status: str,
     timeout_seconds: float = 20,
 ) -> dict:
+    return _wait_for_managed_execution(
+        client,
+        moex_base_url,
+        managed_execution_id,
+        lambda managed_execution: managed_execution["status"] == expected_status,
+        expected_description=expected_status,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _wait_for_managed_execution(
+    client: httpx.Client,
+    moex_base_url: str,
+    managed_execution_id: str,
+    predicate: Callable[[dict], bool],
+    expected_description: str,
+    timeout_seconds: float = 20,
+) -> dict:
     deadline = time.monotonic() + timeout_seconds
     last_response_text = ""
 
@@ -154,11 +248,11 @@ def _wait_for_managed_execution_status(
         assert response.status_code == HttpStatusCode.OK, response.text
 
         managed_execution = response.json()["managed_execution"]
-        if managed_execution["status"] == expected_status:
+        if predicate(managed_execution):
             return managed_execution
         time.sleep(0.25)
 
     pytest.fail(
-        f"Managed execution {managed_execution_id} did not reach {expected_status} "
+        f"Managed execution {managed_execution_id} did not reach {expected_description} "
         f"within {timeout_seconds} seconds. Last response: {last_response_text}"
     )


### PR DESCRIPTION
## Summary
- Extend Docker MOEX integration coverage so terminal `EXECUTED` managed executions are not overwritten by later cancel requests.
- Add a simulator-backed `broker-cancelled` scenario proving broker-side `CANCELLED` orders remain transient managed-execution work across real service boundaries.
- Generalize the MOEX integration wait helper to support lifecycle predicates, not only final status strings.

## Ticket
- [FIA-160](https://linear.app/fianchetto-labs/issue/FIA-160/add-docker-moex-cancel-and-replacement-lifecycle-scenarios)

## Scope Notes
- This PR intentionally proves existing cancellation/replacement-adjacent rules at the Docker boundary.
- It does not invent a new replacement command or durable re-entry model; that still belongs to the broader orchestration work under FIA-162.

## Verification
- `TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_integration` - 5 passed
- `git diff --check` - clean
