### PR TITLE
FIA-161: Document simulator dogfooding workflow

### DIFF
--- a/docs/docker-poc.md
+++ b/docs/docker-poc.md
@@ -35,11 +35,17 @@ FIANCHETTO_TRADEBOT_STATE_DIR=/app/deploy/docker/demo-state
 ```
 
 The demo state contains fake OAuth-shaped E*Trade values. They are intentionally
-not live brokerage credentials. The simulator-backed Compose profile overrides
-the API endpoint with service DNS:
+not live brokerage credentials. The simulator-backed Compose files override the
+API endpoint with service DNS. The automated integration stack uses:
 
 ```bash
 TRADEBOT_ETRADE_API_BASE_URL=http://etrade-simulator:8090
+```
+
+The local dogfooding stack uses:
+
+```bash
+TRADEBOT_ETRADE_API_BASE_URL=http://tradebot-etrade-simulator:8090
 ```
 
 It also sets a long cache max age for that fake credential document:
@@ -112,6 +118,7 @@ That command builds `tradebot:local`, starts the Compose stack in
 `deploy/docker/docker-compose.local.yml`, waits for service health, and leaves
 the containers running until you stop them. This is the normal dogfooding loop
 for local distributed-mode development.
+For a short command-first runbook, see `docs/simulator-dogfooding.md`.
 
 The local Compose stack uses stable service names that mirror the future
 deployment topology:

--- a/docs/etrade-simulator-contract.md
+++ b/docs/etrade-simulator-contract.md
@@ -49,6 +49,7 @@ The first simulator should support these E*Trade-like routes:
 The simulator also exposes non-E*Trade control routes under `/_simulator`.
 These routes are for tests and local dogfooding only. Production TradeBot
 services should never call them.
+For local Docker dogfooding commands, see `docs/simulator-dogfooding.md`.
 
 | Method | Path | Purpose |
 | --- | --- | --- |
@@ -217,11 +218,19 @@ deliberately sets:
 TRADEBOT_RUN_SERVICE_TESTS=1
 ```
 
-Run Docker-backed service tests intentionally with:
+Run Docker-backed service checks intentionally with the canonical Nox sessions.
+For a stable local stack that you can inspect manually:
 
 ```bash
-TRADEBOT_RUN_SERVICE_TESTS=1 docker compose up -d
-TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s test -- -m docker tests
+python -m nox -s docker_up
+python -m nox -s docker_acceptance
+python -m nox -s docker_down
+```
+
+For a test-owned integration stack with automatic cleanup:
+
+```bash
+TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_integration
 ```
 
 This keeps simple unit-test invocations credentials-free and service-free while

--- a/docs/managed-execution-status.md
+++ b/docs/managed-execution-status.md
@@ -44,7 +44,8 @@ Failure flow:
 
 1. `WORKING`: the worker is actively managing the current brokerage order.
 2. `FAILED`: the worker errored, or the broker reported a terminal adverse
-   status such as `EXPIRED` or `REJECTED` that the manager cannot continue from.
+   status such as `EXPIRED` or an unreconciled `REJECTED` that the manager
+   cannot continue from.
 
 Terminal managed executions are immutable through the cancellation API. Once a
 managed execution reaches `EXECUTED`, `CANCELLED`, or `FAILED`, a later cancel
@@ -67,7 +68,7 @@ managed-execution lifecycle:
 | `EXECUTED` | `EXECUTED` | The managed execution achieved its goal. |
 | `CANCELLED` | `WORKING` | The manager may cancel one underlying order as part of replacement/re-entry; this is not the same as cancelling the managed execution. |
 | `EXPIRED` | `FAILED` | The order reached a terminal state without execution. |
-| `REJECTED` | `FAILED` | The broker rejected the order, so the manager cannot proceed normally. |
+| `REJECTED` | `FAILED`, or `EXECUTED` after reconciliation | The broker rejected the order, so the manager cannot usually proceed normally. If the same order appears in the executed-order list, TradeBot treats the rejection as a broker race and records the order as executed. |
 | `ANY` | Invalid | `ANY` is a query filter, not a real order lifecycle state. |
 
 Intentional managed cancellation is handled by the cancellation path:

--- a/docs/simulator-dogfooding.md
+++ b/docs/simulator-dogfooding.md
@@ -1,0 +1,190 @@
+# Simulator Dogfooding
+
+Use this runbook from the repository root when you want to run the TradeBot
+services as real local Docker processes without live E*Trade credentials.
+
+The simulator-backed stack starts four containers:
+
+| Service | Host URL | What it proves |
+| --- | --- | --- |
+| E*Trade simulator | `http://127.0.0.1:18090` | Fake brokerage HTTP boundary |
+| Orders | `http://127.0.0.1:18080` | Order service process and connector wiring |
+| Quotes | `http://127.0.0.1:18081` | Quote service process and connector wiring |
+| MOEX | `http://127.0.0.1:18082` | Managed execution service-to-service wiring |
+
+Inside the local Docker stack, services talk through Compose DNS. MOEX calls
+`tradebot-orders:8080` and `tradebot-quotes:8081`; orders and quotes call
+`tradebot-etrade-simulator:8090`.
+
+## Start The Local Stack
+
+Install the development package once:
+
+```bash
+python -m pip install -e ".[dev]"
+```
+
+Start the local simulator-backed stack:
+
+```bash
+python -m nox -s docker_up
+```
+
+This builds `tradebot:local`, starts
+`deploy/docker/docker-compose.local.yml`, waits for health checks, and leaves
+the containers running until you stop them.
+
+Check the services:
+
+```bash
+curl http://127.0.0.1:18090/health-check
+curl http://127.0.0.1:18080/health-check
+curl http://127.0.0.1:18081/health-check
+curl http://127.0.0.1:18082/health-check
+```
+
+Try a simulator-backed quote:
+
+```bash
+curl http://127.0.0.1:18081/api/v1/ETRADE/quotes/tradable/GE
+```
+
+Run the local acceptance checks against the already-running stack:
+
+```bash
+python -m nox -s docker_acceptance
+```
+
+`docker_acceptance` does not start or stop containers. It expects `docker_up`
+to have already started the stack.
+
+## Simulator Scenarios
+
+Control routes live under `/_simulator` on the simulator service. Production
+TradeBot services should not call them.
+
+Reset simulator state:
+
+```bash
+curl -X POST http://127.0.0.1:18090/_simulator/reset
+```
+
+Select an order lifecycle scenario:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"scenario":"eventually-executed"}' \
+  http://127.0.0.1:18090/_simulator/order-lifecycle-scenario
+```
+
+Supported scenarios:
+
+| Scenario | Behavior |
+| --- | --- |
+| `open` | Order status reads remain `OPEN`. |
+| `eventually-executed` | The first status read is `OPEN`; later reads are `EXECUTED`. |
+| `broker-cancelled` | The first status read is `OPEN`; later reads are `CANCELLED`. |
+| `rejected` | Status reads return `REJECTED`. |
+
+For full MOEX request examples, use the executable Docker integration tests in
+`tests/integration/docker/test_moex_service_stack.py`. Those tests create
+managed executions through the MOEX HTTP service, select simulator scenarios,
+and assert the resulting managed-execution lifecycle.
+
+For a runnable managed-execution happy path without hand-writing the request
+body, run:
+
+```bash
+python -m nox -s docker_acceptance
+```
+
+That command exercises the already-running local stack through the same HTTP
+boundaries used by the Docker integration suite.
+
+## Logs And Cleanup
+
+Show all local stack logs:
+
+```bash
+python -m nox -s docker_logs
+```
+
+Show one service:
+
+```bash
+python -m nox -s docker_logs -- tradebot-moex
+```
+
+Stop and remove the local stack:
+
+```bash
+python -m nox -s docker_down
+```
+
+## Automated Docker Checks
+
+Smoke checks prove container startup and health checks:
+
+```bash
+TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_smoke
+```
+
+Docker integration checks prove service-to-service behavior across real local
+containers:
+
+```bash
+TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_integration
+```
+
+Local `docker_integration` runs leave the integration containers available for
+30 minutes by default. That gives you time to inspect logs or see the stack in
+Docker Desktop. CI cleans up immediately.
+
+Clean up integration containers immediately:
+
+```bash
+TRADEBOT_RUN_SERVICE_TESTS=1 TRADEBOT_INTEGRATION_STACK_TTL_SECONDS=0 python -m nox -s docker_integration
+```
+
+Keep them for a different local TTL:
+
+```bash
+TRADEBOT_RUN_SERVICE_TESTS=1 TRADEBOT_INTEGRATION_STACK_TTL_SECONDS=3600 python -m nox -s docker_integration
+```
+
+Remove the integration stack manually:
+
+```bash
+docker compose -f deploy/docker/docker-compose.integration.yml down --volumes --remove-orphans
+```
+
+## Test Layer Boundaries
+
+Use the safe service-free layers for fast feedback:
+
+```bash
+python -m nox -s unit
+python -m nox -s functional
+```
+
+Use Docker-backed tests when the thing you need to prove involves process
+startup, health checks, Docker DNS, port mapping, service-to-service HTTP,
+runtime connector base URLs, or serialization over the wire.
+
+Use live paper-account E*Trade tests only for brokerage behavior the simulator
+cannot prove:
+
+```bash
+TRADEBOT_RUN_LIVE_E2E_TESTS=1 python -m nox -s live_e2e
+```
+
+Do not use simulator-backed success as evidence that live brokerage credentials,
+E*Trade OAuth, market-hours behavior, or broker-side validation is correct.
+
+## Related Docs
+
+- `docs/testing.md` explains the full test pyramid and Nox sessions.
+- `docs/docker-poc.md` explains the Docker image and Compose topology.
+- `docs/etrade-simulator-contract.md` describes the simulator API contract and
+  seed data.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -118,6 +118,7 @@ python -m nox -s docker_acceptance
 
 This reuses the Docker integration tests as an explicit local acceptance pass.
 It does not start or stop containers; run `docker_up` first.
+For a step-by-step local runbook, see `docs/simulator-dogfooding.md`.
 
 Inspect logs:
 
@@ -198,6 +199,8 @@ docker compose -f deploy/docker/docker-compose.integration.yml down --volumes --
 Use `docker_integration` for an automated test-owned stack with TTL cleanup.
 Use `docker_up` / `docker_down` when you want a stable local runtime to inspect
 manually.
+The manual simulator-backed workflow is documented in
+`docs/simulator-dogfooding.md`.
 
 The live paper-account E*Trade session is reserved for FIA-153 and must remain
 separately gated:


### PR DESCRIPTION
## Summary
- Add a command-first simulator dogfooding runbook for the local Docker stack.
- Link the runbook from the testing, Docker POC, and E*Trade simulator contract docs.
- Replace stale raw Docker test commands with the canonical Nox sessions.
- Clarify local vs integration Compose DNS names and document the managed-execution `REJECTED` reconciliation nuance.

## Ticket
- [FIA-161](https://linear.app/fianchetto-labs/issue/FIA-161/document-simulator-scenario-dogfooding-workflow)

## Verification
- `.venv/bin/python -m nox --list-sessions` passed
- `.venv/bin/python -m nox -s docker_up` passed; all four local stack containers became healthy
- `.venv/bin/python -m nox -s docker_acceptance` passed: 5 tests
- `git diff --check` passed

## Notes
- The local dogfooding stack is left running after `docker_up`, by design. Stop it with `python -m nox -s docker_down` when done inspecting it.
