### PR TITLE
FIA-138 FIA-152: Document deployment modes and centralize Docker fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ accounts = client.get_accounts()
 For local development setup and related guides, see:
 
 - [`dev_get_started_guides/set_up_local_env.MD`](dev_get_started_guides/set_up_local_env.MD)
+- [`docs/deployment.md`](docs/deployment.md)
 - [`docs/serialization.md`](docs/serialization.md)
 - [`dev_get_started_guides/exchange_setup.MD`](dev_get_started_guides/exchange_setup.MD) only if your
   work explicitly needs real or sandbox brokerage credentials.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,116 @@
+# Deployment Modes
+
+TradeBot currently supports three practical local execution modes and has a
+planned Kubernetes direction. Pick the smallest mode that proves the behavior
+you care about.
+
+## Local In-Process Debugging
+
+Use local Python and in-process adapters when you are changing domain behavior,
+request models, parsers, tactics, or service logic and do not need separate
+processes.
+
+Typical commands:
+
+```bash
+python -m nox -s unit
+python -m nox -s functional
+python -m nox -s test -- tests/common/test_chain.py
+```
+
+This mode is fast and easy to debug. It does not prove container startup,
+Docker DNS, port mapping, or service-to-service HTTP wiring.
+
+## Local Docker/Compose Simulator Mode
+
+Use the simulator-backed Compose stack when you want a demoable local runtime
+without live brokerage credentials.
+
+```bash
+python -m nox -s docker_up
+python -m nox -s docker_acceptance
+python -m nox -s docker_down
+```
+
+This starts the E*Trade simulator plus orders, quotes, and MOEX as local
+containers. Services talk through Compose DNS, and host traffic reaches them on
+localhost ports. This is the best mode for manual dogfooding and local demos.
+
+Health checks are exposed on localhost:
+
+```bash
+curl http://127.0.0.1:18090/health-check
+curl http://127.0.0.1:18080/health-check
+curl http://127.0.0.1:18081/health-check
+curl http://127.0.0.1:18082/health-check
+```
+
+## Automated Docker Integration
+
+Use the Docker integration session when you want tests to own stack startup,
+verification, logs, and cleanup.
+
+```bash
+TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_integration
+```
+
+This mode starts a test-owned Compose stack, runs Docker integration tests, and
+uses TTL cleanup for local inspection. It proves service startup,
+service-to-service HTTP, Docker DNS, connector base URLs, serialization over the
+wire, and representative managed-execution behavior.
+
+Use Docker smoke checks when you only need startup and health-check confidence:
+
+```bash
+TRADEBOT_RUN_SERVICE_TESTS=1 python -m nox -s docker_smoke
+```
+
+## Configuration And Secrets
+
+The simulator-backed Docker modes use checked-in fake OAuth-shaped state under
+`deploy/docker/demo-state`. Those values are intentionally not live brokerage
+credentials, but they still exercise the normal credential-loading path.
+
+Live brokerage credentials should stay out of Git. Do not commit OAuth tokens,
+account identifiers, generated credential caches, private keys, or local state
+directories containing real account data.
+
+Important runtime configuration:
+
+| Variable | Purpose |
+| --- | --- |
+| `FIANCHETTO_TRADEBOT_STATE_DIR` | Points a service at its credential/state directory. |
+| `TRADEBOT_ETRADE_API_BASE_URL` | Overrides the E*Trade-compatible API endpoint, commonly to the simulator service in Docker. |
+| `TRADEBOT_MOEX_SERVICE_ADAPTER_MODE` | Selects local vs HTTP-backed MOEX dependencies. |
+| `TRADEBOT_ORDERS_SERVICE_URL` | Tells MOEX where the orders service lives in HTTP mode. |
+| `TRADEBOT_QUOTES_SERVICE_URL` | Tells MOEX where the quotes service lives in HTTP mode. |
+
+## Troubleshooting
+
+- If a Nox Docker command skips, confirm `TRADEBOT_RUN_SERVICE_TESTS=1` is set
+  for service, Docker, or integration sessions.
+- If a service cannot reach another service from inside Docker, check the
+  Compose service URL, not the host `127.0.0.1` URL.
+- If health checks fail, inspect logs with `python -m nox -s docker_logs` or
+  `python -m nox -s docker_logs -- tradebot-moex`.
+- If ports are already in use, stop stale local containers with
+  `python -m nox -s docker_down` and remove stale integration stacks with
+  `docker compose -f deploy/docker/docker-compose.integration.yml down --volumes --remove-orphans`.
+- If a service starts locally but fails in Docker, compare the state directory,
+  base URL override, adapter mode, and service URL environment variables.
+
+## Future Kubernetes Mode
+
+Kubernetes is not implemented yet in this repository. The current Docker and
+Compose work is intentionally shaping the service boundaries that Kubernetes
+will need later: one process per service, explicit ports, health checks,
+container-friendly configuration, and service-to-service URLs.
+
+When Kubernetes support lands, it should reuse those same boundaries rather
+than introduce a separate service model.
+
+## Related Docs
+
+- `docs/testing.md` lists the test pyramid and Nox commands.
+- `docs/docker-poc.md` explains the Docker image and Compose topology.
+- `docs/simulator-dogfooding.md` is the command-first local demo runbook.

--- a/docs/docker-poc.md
+++ b/docs/docker-poc.md
@@ -4,6 +4,9 @@ FIA-133 introduces one reusable image for local container startup checks. The
 image can run each current REST service by selecting the Python module at
 container start.
 
+For the broader local, Docker, and future Kubernetes deployment map, see
+`docs/deployment.md`.
+
 The Compose-backed integration slices start the E*Trade simulator plus the
 quotes, orders, and MOEX services. TradeBot services reach the simulator and
 each other through Docker service DNS, so this proves more than container

--- a/docs/simulator-dogfooding.md
+++ b/docs/simulator-dogfooding.md
@@ -3,6 +3,9 @@
 Use this runbook from the repository root when you want to run the TradeBot
 services as real local Docker processes without live E*Trade credentials.
 
+For the broader deployment-mode map, including what Kubernetes support still
+needs, see `docs/deployment.md`.
+
 The simulator-backed stack starts four containers:
 
 | Service | Host URL | What it proves |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,6 +3,10 @@
 TradeBot uses a test pyramid with explicit commands and explicit safety gates.
 Nox is the canonical interface for routine local validation and CI.
 
+For how these test layers map to local in-process, local Docker, automated
+Docker integration, and future Kubernetes deployment modes, see
+`docs/deployment.md`.
+
 Raw `python -m pytest` can still be useful as a tight local debugging escape
 hatch, but shared project workflows should use Nox so local and CI behavior
 stay aligned.

--- a/tests/fixtures/docker_service_stack.py
+++ b/tests/fixtures/docker_service_stack.py
@@ -1,0 +1,118 @@
+import os
+import time
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from fianchetto_tradebot.server.common.api.http_status_code import HttpStatusCode
+
+
+ETRADE_SIMULATOR_BASE_URL_ENV_VAR = "TRADEBOT_TEST_ETRADE_SIMULATOR_BASE_URL"
+MOEX_BASE_URL_ENV_VAR = "TRADEBOT_TEST_MOEX_BASE_URL"
+ORDERS_BASE_URL_ENV_VAR = "TRADEBOT_TEST_ORDERS_BASE_URL"
+QUOTES_BASE_URL_ENV_VAR = "TRADEBOT_TEST_QUOTES_BASE_URL"
+
+
+@pytest.fixture
+def etrade_simulator_base_url() -> str:
+    return _configured_base_url(
+        ETRADE_SIMULATOR_BASE_URL_ENV_VAR,
+        "E*Trade simulator service stack tests",
+    )
+
+
+@pytest.fixture
+def moex_base_url() -> str:
+    return _configured_base_url(MOEX_BASE_URL_ENV_VAR, "MOEX service stack tests")
+
+
+@pytest.fixture
+def orders_base_url() -> str:
+    return _configured_base_url(ORDERS_BASE_URL_ENV_VAR, "orders service stack tests")
+
+
+@pytest.fixture
+def quotes_base_url() -> str:
+    return _configured_base_url(QUOTES_BASE_URL_ENV_VAR, "quotes service stack tests")
+
+
+@pytest.fixture
+def docker_service_stack() -> "DockerServiceStack":
+    return DockerServiceStack()
+
+
+class DockerServiceStack:
+    def reset_etrade_simulator(
+        self,
+        client: httpx.Client,
+        etrade_simulator_base_url: str,
+    ) -> None:
+        response = client.post(f"{etrade_simulator_base_url}/_simulator/reset")
+        assert response.status_code == HttpStatusCode.OK, response.text
+
+    def set_etrade_order_lifecycle_scenario(
+        self,
+        client: httpx.Client,
+        etrade_simulator_base_url: str,
+        scenario: str,
+    ) -> None:
+        response = client.post(
+            f"{etrade_simulator_base_url}/_simulator/order-lifecycle-scenario",
+            json={"scenario": scenario},
+        )
+        assert response.status_code == HttpStatusCode.OK, response.text
+        assert response.json()["scenario"] == scenario
+
+    def wait_for_managed_execution_status(
+        self,
+        client: httpx.Client,
+        moex_base_url: str,
+        managed_execution_id: str,
+        expected_status: str,
+        timeout_seconds: float = 20,
+    ) -> dict:
+        return self.wait_for_managed_execution(
+            client,
+            moex_base_url,
+            managed_execution_id,
+            lambda managed_execution: managed_execution["status"] == expected_status,
+            expected_description=expected_status,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def wait_for_managed_execution(
+        self,
+        client: httpx.Client,
+        moex_base_url: str,
+        managed_execution_id: str,
+        predicate: Callable[[dict], bool],
+        expected_description: str,
+        timeout_seconds: float = 20,
+    ) -> dict:
+        deadline = time.monotonic() + timeout_seconds
+        last_response_text = ""
+
+        while time.monotonic() < deadline:
+            response = client.get(
+                f"{moex_base_url}/api/v1/managed-executions/{managed_execution_id}"
+            )
+            last_response_text = response.text
+            assert response.status_code == HttpStatusCode.OK, response.text
+
+            managed_execution = response.json()["managed_execution"]
+            if predicate(managed_execution):
+                return managed_execution
+            time.sleep(0.25)
+
+        pytest.fail(
+            f"Managed execution {managed_execution_id} did not reach {expected_description} "
+            f"within {timeout_seconds} seconds. Last response: {last_response_text}"
+        )
+
+
+def _configured_base_url(env_var: str, test_description: str) -> str:
+    base_url = os.getenv(env_var)
+    if not base_url:
+        pytest.skip(f"set {env_var} to run {test_description}")
+    return base_url.rstrip("/")

--- a/tests/integration/docker/conftest.py
+++ b/tests/integration/docker/conftest.py
@@ -1,1 +1,14 @@
-pytest_plugins = ("tests.fixtures.docker_service_stack",)
+from tests.fixtures.docker_service_stack import docker_service_stack
+from tests.fixtures.docker_service_stack import etrade_simulator_base_url
+from tests.fixtures.docker_service_stack import moex_base_url
+from tests.fixtures.docker_service_stack import orders_base_url
+from tests.fixtures.docker_service_stack import quotes_base_url
+
+
+__all__ = [
+    "docker_service_stack",
+    "etrade_simulator_base_url",
+    "moex_base_url",
+    "orders_base_url",
+    "quotes_base_url",
+]

--- a/tests/integration/docker/conftest.py
+++ b/tests/integration/docker/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ("tests.fixtures.docker_service_stack",)

--- a/tests/integration/docker/test_moex_service_stack.py
+++ b/tests/integration/docker/test_moex_service_stack.py
@@ -1,7 +1,3 @@
-import os
-import time
-from collections.abc import Callable
-
 import httpx
 import pytest
 
@@ -20,27 +16,9 @@ from tests.fixtures.etrade_simulator_contract import demo_order
 
 pytestmark = [pytest.mark.service, pytest.mark.docker, pytest.mark.integration]
 
-ETRADE_SIMULATOR_BASE_URL_ENV_VAR = "TRADEBOT_TEST_ETRADE_SIMULATOR_BASE_URL"
-MOEX_BASE_URL_ENV_VAR = "TRADEBOT_TEST_MOEX_BASE_URL"
-
-
-@pytest.fixture
-def etrade_simulator_base_url() -> str:
-    base_url = os.getenv(ETRADE_SIMULATOR_BASE_URL_ENV_VAR)
-    if not base_url:
-        pytest.skip(f"set {ETRADE_SIMULATOR_BASE_URL_ENV_VAR} to run MOEX service stack tests")
-    return base_url.rstrip("/")
-
-
-@pytest.fixture
-def moex_base_url() -> str:
-    base_url = os.getenv(MOEX_BASE_URL_ENV_VAR)
-    if not base_url:
-        pytest.skip(f"set {MOEX_BASE_URL_ENV_VAR} to run MOEX service stack tests")
-    return base_url.rstrip("/")
-
 
 def test_moex_service_runs_networked_managed_execution_lifecycle(
+    docker_service_stack,
     etrade_simulator_base_url: str,
     moex_base_url: str,
 ):
@@ -56,7 +34,7 @@ def test_moex_service_runs_networked_managed_execution_lifecycle(
     )
 
     with httpx.Client(timeout=20) as client:
-        _reset_etrade_simulator(client, etrade_simulator_base_url)
+        docker_service_stack.reset_etrade_simulator(client, etrade_simulator_base_url)
         health_response = client.get(f"{moex_base_url}/health-check")
 
         # When
@@ -88,6 +66,7 @@ def test_moex_service_runs_networked_managed_execution_lifecycle(
 
 
 def test_moex_service_observes_networked_managed_execution_success(
+    docker_service_stack,
     etrade_simulator_base_url: str,
     moex_base_url: str,
 ):
@@ -103,8 +82,8 @@ def test_moex_service_observes_networked_managed_execution_success(
     )
 
     with httpx.Client(timeout=20) as client:
-        _reset_etrade_simulator(client, etrade_simulator_base_url)
-        _set_etrade_order_lifecycle_scenario(
+        docker_service_stack.reset_etrade_simulator(client, etrade_simulator_base_url)
+        docker_service_stack.set_etrade_order_lifecycle_scenario(
             client,
             etrade_simulator_base_url,
             "eventually-executed",
@@ -119,7 +98,7 @@ def test_moex_service_observes_networked_managed_execution_success(
 
         assert create_response.status_code == HttpStatusCode.OK, create_response.text
         managed_execution_id = create_response.json()["managed_execution_id"]
-        managed_execution = _wait_for_managed_execution_status(
+        managed_execution = docker_service_stack.wait_for_managed_execution_status(
             client,
             moex_base_url,
             managed_execution_id,
@@ -141,6 +120,7 @@ def test_moex_service_observes_networked_managed_execution_success(
 
 
 def test_moex_service_treats_broker_cancelled_order_as_transient_work(
+    docker_service_stack,
     etrade_simulator_base_url: str,
     moex_base_url: str,
 ):
@@ -156,8 +136,8 @@ def test_moex_service_treats_broker_cancelled_order_as_transient_work(
     )
 
     with httpx.Client(timeout=20) as client:
-        _reset_etrade_simulator(client, etrade_simulator_base_url)
-        _set_etrade_order_lifecycle_scenario(
+        docker_service_stack.reset_etrade_simulator(client, etrade_simulator_base_url)
+        docker_service_stack.set_etrade_order_lifecycle_scenario(
             client,
             etrade_simulator_base_url,
             "broker-cancelled",
@@ -172,7 +152,7 @@ def test_moex_service_treats_broker_cancelled_order_as_transient_work(
 
         assert create_response.status_code == HttpStatusCode.OK, create_response.text
         managed_execution_id = create_response.json()["managed_execution_id"]
-        working_after_broker_cancel = _wait_for_managed_execution(
+        working_after_broker_cancel = docker_service_stack.wait_for_managed_execution(
             client,
             moex_base_url,
             managed_execution_id,
@@ -194,65 +174,3 @@ def test_moex_service_treats_broker_cancelled_order_as_transient_work(
     assert working_after_broker_cancel["current_order_status"] == "CANCELLED"
     assert cancel_response.status_code == HttpStatusCode.OK, cancel_response.text
     assert cancel_response.json()["managed_execution"]["status"] == "CANCELLED"
-
-
-def _reset_etrade_simulator(client: httpx.Client, etrade_simulator_base_url: str) -> None:
-    response = client.post(f"{etrade_simulator_base_url}/_simulator/reset")
-    assert response.status_code == HttpStatusCode.OK, response.text
-
-
-def _set_etrade_order_lifecycle_scenario(
-    client: httpx.Client,
-    etrade_simulator_base_url: str,
-    scenario: str,
-) -> None:
-    response = client.post(
-        f"{etrade_simulator_base_url}/_simulator/order-lifecycle-scenario",
-        json={"scenario": scenario},
-    )
-    assert response.status_code == HttpStatusCode.OK, response.text
-    assert response.json()["scenario"] == scenario
-
-
-def _wait_for_managed_execution_status(
-    client: httpx.Client,
-    moex_base_url: str,
-    managed_execution_id: str,
-    expected_status: str,
-    timeout_seconds: float = 20,
-) -> dict:
-    return _wait_for_managed_execution(
-        client,
-        moex_base_url,
-        managed_execution_id,
-        lambda managed_execution: managed_execution["status"] == expected_status,
-        expected_description=expected_status,
-        timeout_seconds=timeout_seconds,
-    )
-
-
-def _wait_for_managed_execution(
-    client: httpx.Client,
-    moex_base_url: str,
-    managed_execution_id: str,
-    predicate: Callable[[dict], bool],
-    expected_description: str,
-    timeout_seconds: float = 20,
-) -> dict:
-    deadline = time.monotonic() + timeout_seconds
-    last_response_text = ""
-
-    while time.monotonic() < deadline:
-        response = client.get(f"{moex_base_url}/api/v1/managed-executions/{managed_execution_id}")
-        last_response_text = response.text
-        assert response.status_code == HttpStatusCode.OK, response.text
-
-        managed_execution = response.json()["managed_execution"]
-        if predicate(managed_execution):
-            return managed_execution
-        time.sleep(0.25)
-
-    pytest.fail(
-        f"Managed execution {managed_execution_id} did not reach {expected_description} "
-        f"within {timeout_seconds} seconds. Last response: {last_response_text}"
-    )

--- a/tests/integration/docker/test_orders_service_stack.py
+++ b/tests/integration/docker/test_orders_service_stack.py
@@ -1,5 +1,3 @@
-import os
-
 import httpx
 import pytest
 
@@ -12,34 +10,16 @@ from tests.fixtures.etrade_simulator_contract import demo_preview_order_request
 
 pytestmark = [pytest.mark.service, pytest.mark.docker, pytest.mark.integration]
 
-ETRADE_SIMULATOR_BASE_URL_ENV_VAR = "TRADEBOT_TEST_ETRADE_SIMULATOR_BASE_URL"
-ORDERS_BASE_URL_ENV_VAR = "TRADEBOT_TEST_ORDERS_BASE_URL"
-
-
-@pytest.fixture
-def etrade_simulator_base_url() -> str:
-    base_url = os.getenv(ETRADE_SIMULATOR_BASE_URL_ENV_VAR)
-    if not base_url:
-        pytest.skip(f"set {ETRADE_SIMULATOR_BASE_URL_ENV_VAR} to run orders service stack tests")
-    return base_url.rstrip("/")
-
-
-@pytest.fixture
-def orders_base_url() -> str:
-    base_url = os.getenv(ORDERS_BASE_URL_ENV_VAR)
-    if not base_url:
-        pytest.skip(f"set {ORDERS_BASE_URL_ENV_VAR} to run orders service stack tests")
-    return base_url.rstrip("/")
-
 
 def test_orders_service_runs_simulator_backed_order_lifecycle(
+    docker_service_stack,
     etrade_simulator_base_url: str,
     orders_base_url: str,
 ):
     preview_request = demo_preview_order_request()
 
     with httpx.Client(timeout=5) as client:
-        reset_response = client.post(f"{etrade_simulator_base_url}/_simulator/reset")
+        docker_service_stack.reset_etrade_simulator(client, etrade_simulator_base_url)
         health_response = client.get(f"{orders_base_url}/health-check")
         preview_response = client.post(
             f"{orders_base_url}/api/v1/ETRADE/accounts/{ACCOUNT_ID}/orders/preview",
@@ -67,8 +47,6 @@ def test_orders_service_runs_simulator_backed_order_lifecycle(
         cancel_response = client.delete(
             f"{orders_base_url}/api/v1/ETRADE/accounts/{ACCOUNT_ID}/orders/{ORDER_ID}"
         )
-
-    assert reset_response.status_code == HttpStatusCode.OK
 
     assert health_response.status_code == HttpStatusCode.OK
     assert health_response.json() == "ORDERS Service Up"

--- a/tests/integration/docker/test_quotes_service_stack.py
+++ b/tests/integration/docker/test_quotes_service_stack.py
@@ -1,20 +1,8 @@
-import os
-
 import httpx
 import pytest
 
 
 pytestmark = [pytest.mark.service, pytest.mark.docker, pytest.mark.integration]
-
-QUOTES_BASE_URL_ENV_VAR = "TRADEBOT_TEST_QUOTES_BASE_URL"
-
-
-@pytest.fixture
-def quotes_base_url() -> str:
-    base_url = os.getenv(QUOTES_BASE_URL_ENV_VAR)
-    if not base_url:
-        pytest.skip(f"set {QUOTES_BASE_URL_ENV_VAR} to run quotes service stack tests")
-    return base_url.rstrip("/")
 
 
 def test_quotes_service_returns_simulator_backed_equity_quote(quotes_base_url: str):


### PR DESCRIPTION
## Summary
- add a deployment modes guide for local in-process, local Docker/Compose simulator mode, automated Docker integration, config/secrets, troubleshooting, and future Kubernetes direction
- link the deployment guide from README, Docker POC, simulator dogfooding, and testing docs
- centralize Docker integration pytest fixtures and service-stack helpers under tests/fixtures so tests stay focused on Given/When/Then behavior

## Tickets
- [FIA-138](https://linear.app/fianchetto-labs/issue/FIA-138/document-tradebot-local-docker-and-kubernetes-deployment-modes)
- [FIA-152](https://linear.app/fianchetto-labs/issue/FIA-152/add-reusable-docker-service-test-lifecycle-harness)

## Tracker Reconciliation
This PR also provides evidence for stale/nearby tickets that are already satisfied by the current repo state:
- [FIA-16](https://linear.app/fianchetto-labs/issue/FIA-16/document-tradebot-testing-pyramid-and-local-test-commands)
- [FIA-135](https://linear.app/fianchetto-labs/issue/FIA-135/add-local-and-http-service-adapters-for-tradebot-service-dependencies)
- [FIA-142](https://linear.app/fianchetto-labs/issue/FIA-142/add-runtime-wiring-for-local-vs-http-service-dependency-mode)
- [FIA-144](https://linear.app/fianchetto-labs/issue/FIA-144/add-dockerized-etrade-simulator-for-deployment-demos)
- [FIA-148](https://linear.app/fianchetto-labs/issue/FIA-148/wire-etrade-simulator-into-docker-compose-deployment-demo)
- [FIA-150](https://linear.app/fianchetto-labs/issue/FIA-150/document-simulator-backed-deployment-mode)

## Verification
- `git diff --check`
- `.venv/bin/python -m pytest --collect-only -q tests/integration/docker`
- `.venv/bin/python -m pytest -q tests/integration/docker`
- `.venv/bin/python -m pytest -q tests/common/service/test_local_service_adapters.py tests/common/service/test_http_service_adapters.py tests/common/service/test_service_adapter_contracts.py tests/common/service/test_moex_rest_service_composition.py`
- `TRADEBOT_RUN_SERVICE_TESTS=1 TRADEBOT_INTEGRATION_STACK_TTL_SECONDS=0 .venv/bin/python -m nox -s docker_integration`

## Notes
- Docker integration was rerun after closing parallel workers and clearing Compose stacks so only one owner touched the integration stack.
- Kubernetes remains explicitly documented as future work; this PR documents the direction without pretending manifests exist yet.