### PR TITLE
FIA-163: Define managed execution state transitions

### DIFF
--- a/docs/managed-execution-status.md
+++ b/docs/managed-execution-status.md
@@ -15,8 +15,8 @@ even when their values sound similar.
 
 | Status | Meaning |
 | --- | --- |
-| `PRE_SUBMISSION` | The managed execution exists, but the worker has not yet established and observed the current brokerage order. |
-| `WORKING` | The worker is actively managing the execution, including observing the order, repricing, replacing, or waiting. |
+| `PRE_SUBMISSION` | The managed execution exists, but the worker has not yet established and checked the current brokerage order. |
+| `WORKING` | The worker is actively managing the execution, including checking the order, repricing, replacing, or waiting. |
 | `CANCEL_REQUESTED` | A user or system action has asked the worker to stop managing the execution and cancel the current order. |
 | `CANCELLED` | TradeBot intentionally stopped the managed execution. |
 | `EXECUTED` | The managed execution completed successfully because the underlying order executed. |
@@ -27,12 +27,17 @@ even when their values sound similar.
 The managed execution status should describe TradeBot's next orchestration
 decision, not merely repeat the broker's status string.
 
+The status-change rules live in
+`fianchetto_tradebot.common_models.managed_executions.managed_execution_status`.
+Worker and cancellation code should use the status-change helper there
+instead of assigning managed execution status directly.
+
 Normal managed execution flow:
 
 1. `PRE_SUBMISSION`: the API has accepted the managed execution request.
 2. `WORKING`: the worker has created or found the current brokerage order and
    is responsible for monitoring and repricing it.
-3. `EXECUTED`: the worker observed the brokerage order complete successfully.
+3. `EXECUTED`: the worker checked the brokerage order and found it complete.
 
 Intentional cancellation flow:
 
@@ -52,11 +57,20 @@ managed execution reaches `EXECUTED`, `CANCELLED`, or `FAILED`, a later cancel
 request must return the existing managed execution state without cancelling the
 underlying brokerage order or rewriting the managed execution status.
 
+Invalid non-idempotent status changes raise `InvalidManagedExecutionStatusChange`.
+Reapplying the same status is idempotent, which keeps repeated checks of
+an already-recorded state safe.
+
 ## Brokerage Status Translation
 
-When MOEX observes the current brokerage order, it records the raw brokerage
-status in `current_order_status`. It then translates that observation into the
+When MOEX checks the current brokerage order, it records the raw brokerage
+status in `current_order_status`. It then translates that order status into the
 managed-execution lifecycle:
+
+The default translation is table-driven. Context-specific overrides are only
+used when the current managed execution status matters. Today, the important
+override is cancellation: once a managed execution is `CANCEL_REQUESTED`, a
+later active-looking brokerage order check must not move it back to `WORKING`.
 
 | Brokerage `OrderStatus` | Managed `ManagedExecutionStatus` | Rationale |
 | --- | --- | --- |

--- a/src/fianchetto_tradebot/common_models/managed_executions/managed_execution_status.py
+++ b/src/fianchetto_tradebot/common_models/managed_executions/managed_execution_status.py
@@ -12,6 +12,10 @@ class ManagedExecutionStatus(str, Enum):
     FAILED = "FAILED"
 
 
+class InvalidManagedExecutionStatusChange(ValueError):
+    pass
+
+
 TERMINAL_MANAGED_EXECUTION_STATUSES = frozenset(
     {
         ManagedExecutionStatus.CANCELLED,
@@ -21,15 +25,103 @@ TERMINAL_MANAGED_EXECUTION_STATUSES = frozenset(
 )
 
 
+_MANAGED_EXECUTION_STATUS_BY_ORDER_STATUS = {
+    OrderStatus.OPEN: ManagedExecutionStatus.WORKING,
+    OrderStatus.PARTIAL: ManagedExecutionStatus.WORKING,
+    OrderStatus.INDIVIDUAL_FILLS: ManagedExecutionStatus.WORKING,
+    OrderStatus.CANCEL_REQUESTED: ManagedExecutionStatus.WORKING,
+    OrderStatus.PRE_SUBMISSION: ManagedExecutionStatus.WORKING,
+    OrderStatus.CANCELLED: ManagedExecutionStatus.WORKING,
+    OrderStatus.EXECUTED: ManagedExecutionStatus.EXECUTED,
+    OrderStatus.EXPIRED: ManagedExecutionStatus.FAILED,
+    OrderStatus.REJECTED: ManagedExecutionStatus.FAILED,
+}
+
+
+_ORDER_CHECK_STATUS_OVERRIDES = {
+    (
+        ManagedExecutionStatus.CANCEL_REQUESTED,
+        ManagedExecutionStatus.WORKING,
+    ): ManagedExecutionStatus.CANCEL_REQUESTED,
+}
+
+
+_ALLOWED_NEXT_MANAGED_EXECUTION_STATUSES = {
+    ManagedExecutionStatus.PRE_SUBMISSION: frozenset(
+        {
+            ManagedExecutionStatus.WORKING,
+            ManagedExecutionStatus.CANCEL_REQUESTED,
+            ManagedExecutionStatus.EXECUTED,
+            ManagedExecutionStatus.FAILED,
+        }
+    ),
+    ManagedExecutionStatus.WORKING: frozenset(
+        {
+            ManagedExecutionStatus.WORKING,
+            ManagedExecutionStatus.CANCEL_REQUESTED,
+            ManagedExecutionStatus.EXECUTED,
+            ManagedExecutionStatus.FAILED,
+        }
+    ),
+    ManagedExecutionStatus.CANCEL_REQUESTED: frozenset(
+        {
+            ManagedExecutionStatus.CANCEL_REQUESTED,
+            ManagedExecutionStatus.CANCELLED,
+            ManagedExecutionStatus.EXECUTED,
+            ManagedExecutionStatus.FAILED,
+        }
+    ),
+}
+
+
 def is_terminal_managed_execution_status(status: ManagedExecutionStatus) -> bool:
     return status in TERMINAL_MANAGED_EXECUTION_STATUSES
 
 
 def managed_execution_status_from_order_status(order_status: OrderStatus) -> ManagedExecutionStatus:
-    if order_status == OrderStatus.EXECUTED:
-        return ManagedExecutionStatus.EXECUTED
-    if order_status in {OrderStatus.EXPIRED, OrderStatus.REJECTED}:
-        return ManagedExecutionStatus.FAILED
     if order_status == OrderStatus.ANY:
         raise ValueError("OrderStatus.ANY is a query filter, not a brokerage lifecycle status")
-    return ManagedExecutionStatus.WORKING
+    try:
+        return _MANAGED_EXECUTION_STATUS_BY_ORDER_STATUS[order_status]
+    except KeyError as exc:
+        raise ValueError(
+            f"No managed execution status decision for order status {order_status.value}"
+        ) from exc
+
+
+def managed_execution_status_after_order_check(
+    current_status: ManagedExecutionStatus,
+    order_status: OrderStatus,
+) -> ManagedExecutionStatus:
+    default_next_status = managed_execution_status_from_order_status(order_status)
+    next_status = _ORDER_CHECK_STATUS_OVERRIDES.get(
+        (current_status, default_next_status),
+        default_next_status,
+    )
+    return managed_execution_status_after_change(
+        current_status=current_status,
+        next_status=next_status,
+    )
+
+
+def managed_execution_status_after_change(
+    current_status: ManagedExecutionStatus,
+    next_status: ManagedExecutionStatus,
+) -> ManagedExecutionStatus:
+    if current_status == next_status:
+        return current_status
+
+    if is_terminal_managed_execution_status(current_status):
+        raise InvalidManagedExecutionStatusChange(
+            "Cannot change managed execution status: "
+            f"{current_status.value} is already terminal"
+        )
+
+    allowed_targets = _ALLOWED_NEXT_MANAGED_EXECUTION_STATUSES.get(current_status, frozenset())
+    if next_status not in allowed_targets:
+        raise InvalidManagedExecutionStatusChange(
+            "Cannot change managed execution status "
+            f"from {current_status.value} to {next_status.value}"
+        )
+
+    return next_status

--- a/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
+++ b/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
@@ -40,7 +40,8 @@ from fianchetto_tradebot.common_models.managed_executions.list_managed_execution
 from fianchetto_tradebot.common_models.managed_executions.managed_execution_status import (
     ManagedExecutionStatus,
     is_terminal_managed_execution_status,
-    managed_execution_status_from_order_status,
+    managed_execution_status_after_change,
+    managed_execution_status_after_order_check,
 )
 from fianchetto_tradebot.common_models.order.action import Action
 from fianchetto_tradebot.common_models.order.expiry.good_until_cancelled import GoodUntilCancelled
@@ -76,7 +77,10 @@ class ManagedExecutionWorker:
         print(f"Moex_id_thread {self.moex_id}: Received command to stop processing")
         self._stop_requested.set()
         if not is_terminal_managed_execution_status(self.moex.status):
-            self.moex.status = ManagedExecutionStatus.CANCEL_REQUESTED
+            self.moex.status = managed_execution_status_after_change(
+                self.moex.status,
+                ManagedExecutionStatus.CANCEL_REQUESTED,
+            )
 
     def should_stop_processing(self) -> bool:
         return self._stop_requested.is_set()
@@ -90,7 +94,10 @@ class ManagedExecutionWorker:
     def record_order_snapshot(self, placed_order: PlacedOrder, orders_service: OrderServicePort) -> OrderStatus:
         current_status = self.resolve_order_status(placed_order, orders_service)
         self.moex.current_order_status = current_status
-        self.moex.status = managed_execution_status_from_order_status(current_status)
+        self.moex.status = managed_execution_status_after_order_check(
+            current_status=self.moex.status,
+            order_status=current_status,
+        )
         return current_status
 
     def resolve_order_status(self, placed_order: PlacedOrder, orders_service: OrderServicePort) -> OrderStatus:
@@ -175,7 +182,11 @@ class ManagedExecutionWorker:
                 if self.should_stop_processing():
                     break
 
-                self.moex.status = ManagedExecutionStatus.WORKING
+                if self.moex.status != ManagedExecutionStatus.CANCEL_REQUESTED:
+                    self.moex.status = managed_execution_status_after_change(
+                        self.moex.status,
+                        ManagedExecutionStatus.WORKING,
+                    )
 
                 print(f"Sleeping {wait_time} seconds")
                 self.wait_before_next_order_status_check(wait_time)
@@ -194,7 +205,11 @@ class ManagedExecutionWorker:
             else:
                 print(f"Moex id {self.moex_id} completed with status {self.moex.status} for latest order-id {order_id} at price {current_price}!")
         except Exception as e:
-            self.moex.status = ManagedExecutionStatus.FAILED
+            if not is_terminal_managed_execution_status(self.moex.status):
+                self.moex.status = managed_execution_status_after_change(
+                    self.moex.status,
+                    ManagedExecutionStatus.FAILED,
+                )
             print(f"Error occurred: {e}")
 
         print(f"Moex_id_thread {self.moex_id}: Finished")
@@ -320,10 +335,16 @@ class MoexService:
             if managed_execution.current_brokerage_order_id:
                 cancel_order_request: CancelOrderRequest = CancelOrderRequest(account_id=managed_execution.account_id, order_id=managed_execution.current_brokerage_order_id)
                 cancel_order_response: CancelOrderResponse = order_service.cancel_order(cancel_order_request)
-                managed_execution.status = ManagedExecutionStatus.CANCELLED
+                managed_execution.status = managed_execution_status_after_change(
+                    managed_execution.status,
+                    ManagedExecutionStatus.CANCELLED,
+                )
                 print(f"Moex id: {managed_execution_id} - cancelled order {cancel_order_response.order_id} at {cancel_order_response.cancel_time}")
             else:
-                managed_execution.status = ManagedExecutionStatus.CANCELLED
+                managed_execution.status = managed_execution_status_after_change(
+                    managed_execution.status,
+                    ManagedExecutionStatus.CANCELLED,
+                )
                 print(f"There is currently no open order for {managed_execution_id}, so nothing to cancel.")
 
             return CancelManagedExecutionResponse(managed_execution=managed_execution)

--- a/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
+++ b/src/fianchetto_tradebot/server/common/api/moex/moex_service.py
@@ -1,3 +1,4 @@
+import logging
 import string
 import threading
 import time
@@ -63,6 +64,10 @@ from fianchetto_tradebot.server.orders.managed_order_execution import ManagedExe
     ManagedExecutionCreationType
 from fianchetto_tradebot.server.orders.tactics.execution_tactic import ExecutionTactic
 
+
+logger = logging.getLogger(__name__)
+
+
 class ManagedExecutionWorker:
     def __init__(self, moex: ManagedExecution, moex_id: str, quotes_services: dict[Brokerage, QuoteServicePort], orders_services: dict[Brokerage, OrderServicePort]):
         # This object gets modified in this process
@@ -74,7 +79,7 @@ class ManagedExecutionWorker:
         self._stop_requested = threading.Event()
 
     def stop(self):
-        print(f"Moex_id_thread {self.moex_id}: Received command to stop processing")
+        logger.info("managed_execution_stop_requested", extra=self.log_context())
         self._stop_requested.set()
         if not is_terminal_managed_execution_status(self.moex.status):
             self.moex.status = managed_execution_status_after_change(
@@ -90,6 +95,21 @@ class ManagedExecutionWorker:
 
     def wait_before_next_order_status_check(self, wait_time: float) -> None:
         self._stop_requested.wait(wait_time)
+
+    def log_context(self, **extra_context) -> dict:
+        return {
+            "moex_id": self.moex_id,
+            "brokerage": self.moex.brokerage.value,
+            "account_ref": _safe_account_reference(self.moex.account_id),
+            "brokerage_order_id": self.moex.current_brokerage_order_id,
+            "managed_execution_status": self.moex.status.value,
+            "brokerage_order_status": (
+                self.moex.current_order_status.value
+                if self.moex.current_order_status
+                else None
+            ),
+            **extra_context,
+        }
 
     def record_order_snapshot(self, placed_order: PlacedOrder, orders_service: OrderServicePort) -> OrderStatus:
         current_status = self.resolve_order_status(placed_order, orders_service)
@@ -123,7 +143,7 @@ class ManagedExecutionWorker:
         )
 
     def __call__(self, *args, **kwargs):
-        print(f"Executing order {self.moex_id}")
+        logger.info("managed_execution_worker_started", extra=self.log_context())
         orders_service = self.orders_services[self.moex.brokerage]
         quotes_service = self.quotes_services[self.moex.brokerage]
         order = self.moex.original_order
@@ -157,7 +177,10 @@ class ManagedExecutionWorker:
 
             if 'event_creation_lock' in kwargs:
                 event: threading.Event = kwargs['event_creation_lock']
-                print(f"Brokerage order {order_id} available for MOEX.")
+                logger.info(
+                    "managed_execution_initial_order_ready",
+                    extra=self.log_context(brokerage_order_id=order_id),
+                )
                 event.set()
 
             order = placed_order.order
@@ -177,8 +200,14 @@ class ManagedExecutionWorker:
                 place_order_response: PlaceOrderResponse = orders_service.modify_order(preview_modify_order_request=preview_modify_order_request)
 
                 order_id = place_order_response.order_id
-                print(f"Successfully placed {place_order_response.order_id} for price {place_order_response.order.order_price}")
                 self.moex.current_brokerage_order_id = order_id
+                logger.info(
+                    "managed_execution_replacement_order_placed",
+                    extra=self.log_context(
+                        brokerage_order_id=order_id,
+                        order_price=str(place_order_response.order.order_price),
+                    ),
+                )
                 if self.should_stop_processing():
                     break
 
@@ -188,7 +217,10 @@ class ManagedExecutionWorker:
                         ManagedExecutionStatus.WORKING,
                     )
 
-                print(f"Sleeping {wait_time} seconds")
+                logger.info(
+                    "managed_execution_waiting_before_broker_poll",
+                    extra=self.log_context(wait_seconds=wait_time),
+                )
                 self.wait_before_next_order_status_check(wait_time)
                 if self.should_stop_processing():
                     break
@@ -201,18 +233,33 @@ class ManagedExecutionWorker:
                 current_price = placed_order.order.order_price
 
             if self.should_stop_processing():
-                print(f"Moex id {self.moex_id} cancelled with latest order-id {order_id} at price {current_price}!")
+                logger.info(
+                    "managed_execution_worker_stopped",
+                    extra=self.log_context(
+                        brokerage_order_id=order_id,
+                        current_price=str(current_price),
+                    ),
+                )
             else:
-                print(f"Moex id {self.moex_id} completed with status {self.moex.status} for latest order-id {order_id} at price {current_price}!")
+                logger.info(
+                    "managed_execution_worker_completed",
+                    extra=self.log_context(
+                        brokerage_order_id=order_id,
+                        current_price=str(current_price),
+                    ),
+                )
         except Exception as e:
             if not is_terminal_managed_execution_status(self.moex.status):
                 self.moex.status = managed_execution_status_after_change(
                     self.moex.status,
                     ManagedExecutionStatus.FAILED,
                 )
-            print(f"Error occurred: {e}")
+            logger.exception(
+                "managed_execution_worker_failed",
+                extra=self.log_context(error_type=type(e).__name__),
+            )
 
-        print(f"Moex_id_thread {self.moex_id}: Finished")
+        logger.info("managed_execution_worker_finished", extra=self.log_context())
 
     @staticmethod
     def generate_random_alphanumeric(length=15):
@@ -228,6 +275,11 @@ def _placed_order_snapshot(order_snapshot: PlacedOrder | ExecutedOrder) -> Place
     if isinstance(order_snapshot, ExecutedOrder):
         return order_snapshot.order
     return order_snapshot
+
+
+def _safe_account_reference(account_id: str) -> str:
+    suffix = account_id[-4:] if len(account_id) > 4 else account_id
+    return f"account:{suffix}"
 
 
 class MoexService:
@@ -251,12 +303,12 @@ class MoexService:
         self._shutdown_engage: bool = False
 
     def run(self):
-        print(f"{ServiceKey.MOEX} service running")
+        logger.info("moex_service_running", extra={"service_key": ServiceKey.MOEX.value})
         try:
             while not self._shutdown_engage:
                 time.sleep(1)  # Idle loop, waiting for tasks
         except KeyboardInterrupt:
-            print("Shutting down application...")
+            logger.info("moex_service_keyboard_interrupt")
             self.shutdown()
 
     ### Managed Executions - to be cleaved off into a separate service
@@ -286,7 +338,7 @@ class MoexService:
             raise HTTPException(status_code=HttpStatusCode.NOT_FOUND, detail=f"Managed execution {managed_execution_id} not found")
 
     def shutdown(self):
-        print("...shutting down...")
+        logger.info("moex_service_shutdown_requested")
         self._shutdown_engage = True
 
     def create_managed_execution(self, create_managed_execution_request: CreateManagedExecutionRequest)->CreateManagedExecutionResponse:
@@ -308,7 +360,16 @@ class MoexService:
             assert success, "Could not create event in a meaningful amount of time"
 
             self.managed_executions[str(new_id)] = (managed_execution, worker, future)
-            print(f"Added new execution {new_id}")
+            logger.info(
+                "managed_execution_created",
+                extra={
+                    "moex_id": str(new_id),
+                    "brokerage": managed_execution.brokerage.value,
+                    "account_ref": _safe_account_reference(managed_execution.account_id),
+                    "managed_execution_status": managed_execution.status.value,
+                    "brokerage_order_id": managed_execution.current_brokerage_order_id,
+                },
+            )
 
         return CreateManagedExecutionResponse(managed_execution_id = str(new_id))
 
@@ -322,7 +383,16 @@ class MoexService:
         with self.managed_executions_lock:
             managed_execution, worker, future = self.managed_executions[managed_execution_id]
             if is_terminal_managed_execution_status(managed_execution.status):
-                print(f"Moex id: {managed_execution_id} already terminal with status {managed_execution.status}.")
+                logger.info(
+                    "managed_execution_cancel_ignored_terminal",
+                    extra={
+                        "moex_id": managed_execution_id,
+                        "brokerage": managed_execution.brokerage.value,
+                        "account_ref": _safe_account_reference(managed_execution.account_id),
+                        "managed_execution_status": managed_execution.status.value,
+                        "brokerage_order_id": managed_execution.current_brokerage_order_id,
+                    },
+                )
                 return CancelManagedExecutionResponse(managed_execution=managed_execution)
 
             # Cancel the future first so it doesn't create a new order after-the-fact
@@ -339,13 +409,32 @@ class MoexService:
                     managed_execution.status,
                     ManagedExecutionStatus.CANCELLED,
                 )
-                print(f"Moex id: {managed_execution_id} - cancelled order {cancel_order_response.order_id} at {cancel_order_response.cancel_time}")
+                logger.info(
+                    "managed_execution_cancel_completed",
+                    extra={
+                        "moex_id": managed_execution_id,
+                        "brokerage": managed_execution.brokerage.value,
+                        "account_ref": _safe_account_reference(managed_execution.account_id),
+                        "managed_execution_status": managed_execution.status.value,
+                        "brokerage_order_id": cancel_order_response.order_id,
+                        "cancel_time": cancel_order_response.cancel_time,
+                    },
+                )
             else:
                 managed_execution.status = managed_execution_status_after_change(
                     managed_execution.status,
                     ManagedExecutionStatus.CANCELLED,
                 )
-                print(f"There is currently no open order for {managed_execution_id}, so nothing to cancel.")
+                logger.info(
+                    "managed_execution_cancel_completed_without_open_order",
+                    extra={
+                        "moex_id": managed_execution_id,
+                        "brokerage": managed_execution.brokerage.value,
+                        "account_ref": _safe_account_reference(managed_execution.account_id),
+                        "managed_execution_status": managed_execution.status.value,
+                        "brokerage_order_id": None,
+                    },
+                )
 
             return CancelManagedExecutionResponse(managed_execution=managed_execution)
 

--- a/tests/common/test_managed_execution_status.py
+++ b/tests/common/test_managed_execution_status.py
@@ -2,9 +2,12 @@ import pytest
 
 from fianchetto_tradebot.common_models.managed_executions.managed_execution_status import (
     TERMINAL_MANAGED_EXECUTION_STATUSES,
+    InvalidManagedExecutionStatusChange,
     ManagedExecutionStatus,
     is_terminal_managed_execution_status,
     managed_execution_status_from_order_status,
+    managed_execution_status_after_change,
+    managed_execution_status_after_order_check,
 )
 from fianchetto_tradebot.common_models.order.order_status import OrderStatus
 
@@ -39,6 +42,23 @@ def test_every_brokerage_order_status_has_an_explicit_managed_execution_decision
 
 def test_brokerage_cancellation_does_not_cancel_or_fail_the_managed_execution():
     assert managed_execution_status_from_order_status(OrderStatus.CANCELLED) == ManagedExecutionStatus.WORKING
+    assert (
+        managed_execution_status_after_order_check(
+            current_status=ManagedExecutionStatus.WORKING,
+            order_status=OrderStatus.CANCELLED,
+        )
+        == ManagedExecutionStatus.WORKING
+    )
+
+
+def test_cancel_request_is_not_cleared_by_later_active_order_check():
+    assert (
+        managed_execution_status_after_order_check(
+            current_status=ManagedExecutionStatus.CANCEL_REQUESTED,
+            order_status=OrderStatus.OPEN,
+        )
+        == ManagedExecutionStatus.CANCEL_REQUESTED
+    )
 
 
 def test_order_status_any_is_not_a_managed_execution_lifecycle_status():
@@ -58,4 +78,65 @@ def test_terminal_managed_execution_statuses_are_explicit():
 def test_terminal_managed_execution_status_policy(status: ManagedExecutionStatus):
     assert is_terminal_managed_execution_status(status) == (
         status in TERMINAL_MANAGED_EXECUTION_STATUSES
+    )
+
+
+@pytest.mark.parametrize(
+    ("current_status", "order_status", "expected_status"),
+    [
+        (ManagedExecutionStatus.PRE_SUBMISSION, OrderStatus.OPEN, ManagedExecutionStatus.WORKING),
+        (ManagedExecutionStatus.PRE_SUBMISSION, OrderStatus.EXECUTED, ManagedExecutionStatus.EXECUTED),
+        (ManagedExecutionStatus.PRE_SUBMISSION, OrderStatus.REJECTED, ManagedExecutionStatus.FAILED),
+        (ManagedExecutionStatus.WORKING, OrderStatus.OPEN, ManagedExecutionStatus.WORKING),
+        (ManagedExecutionStatus.WORKING, OrderStatus.CANCELLED, ManagedExecutionStatus.WORKING),
+        (ManagedExecutionStatus.WORKING, OrderStatus.EXECUTED, ManagedExecutionStatus.EXECUTED),
+        (ManagedExecutionStatus.WORKING, OrderStatus.EXPIRED, ManagedExecutionStatus.FAILED),
+        (ManagedExecutionStatus.WORKING, OrderStatus.REJECTED, ManagedExecutionStatus.FAILED),
+        (ManagedExecutionStatus.CANCEL_REQUESTED, OrderStatus.OPEN, ManagedExecutionStatus.CANCEL_REQUESTED),
+        (ManagedExecutionStatus.CANCEL_REQUESTED, OrderStatus.CANCELLED, ManagedExecutionStatus.CANCEL_REQUESTED),
+        (ManagedExecutionStatus.CANCEL_REQUESTED, OrderStatus.EXECUTED, ManagedExecutionStatus.EXECUTED),
+        (ManagedExecutionStatus.CANCEL_REQUESTED, OrderStatus.EXPIRED, ManagedExecutionStatus.FAILED),
+        (ManagedExecutionStatus.CANCEL_REQUESTED, OrderStatus.REJECTED, ManagedExecutionStatus.FAILED),
+    ],
+)
+def test_checking_order_status_updates_managed_execution_status(
+    current_status: ManagedExecutionStatus,
+    order_status: OrderStatus,
+    expected_status: ManagedExecutionStatus,
+):
+    assert (
+        managed_execution_status_after_order_check(
+            current_status=current_status,
+            order_status=order_status,
+        )
+        == expected_status
+    )
+
+
+def test_invalid_status_change_fails_loudly():
+    with pytest.raises(InvalidManagedExecutionStatusChange, match="from PRE_SUBMISSION to CANCELLED"):
+        managed_execution_status_after_change(
+            current_status=ManagedExecutionStatus.PRE_SUBMISSION,
+            next_status=ManagedExecutionStatus.CANCELLED,
+        )
+
+
+@pytest.mark.parametrize("terminal_status", TERMINAL_MANAGED_EXECUTION_STATUSES)
+def test_terminal_managed_execution_statuses_cannot_be_overwritten(
+    terminal_status: ManagedExecutionStatus,
+):
+    with pytest.raises(InvalidManagedExecutionStatusChange, match="already terminal"):
+        managed_execution_status_after_change(
+            current_status=terminal_status,
+            next_status=ManagedExecutionStatus.WORKING,
+        )
+
+
+def test_terminal_managed_execution_status_can_be_reapplied_idempotently():
+    assert (
+        managed_execution_status_after_change(
+            current_status=ManagedExecutionStatus.EXECUTED,
+            next_status=ManagedExecutionStatus.EXECUTED,
+        )
+        == ManagedExecutionStatus.EXECUTED
     )

--- a/tests/moex/worker/eviction/test_moex_eviction.py
+++ b/tests/moex/worker/eviction/test_moex_eviction.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 from datetime import datetime
 from unittest.mock import MagicMock
@@ -34,6 +35,7 @@ from fianchetto_tradebot.common_models.order.order_status import OrderStatus
 from fianchetto_tradebot.common_models.order.order_type import OrderType
 from fianchetto_tradebot.common_models.order.placed_order import PlacedOrder
 from fianchetto_tradebot.common_models.order.placed_order_details import PlacedOrderDetails
+from fianchetto_tradebot.server.common.api.moex import moex_service as moex_service_module
 from fianchetto_tradebot.server.common.api.moex.moex_service import (
     ManagedExecutionWorker,
     MoexService,
@@ -102,10 +104,11 @@ def test_managed_execution_succeeds_when_brokerage_order_executes(
     order: Order,
     quotes_service_map: dict[Brokerage, QuotesService],
     orders_service_map: dict[Brokerage, OrderService],
-    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ):
     # Given
     # A new managed execution request whose brokerage order is immediately executed.
+    caplog.set_level(logging.INFO, logger=moex_service_module.__name__)
     mock_order_service = orders_service_map[Brokerage.ETRADE]
     moex_service = MoexService(quotes_services=quotes_service_map, orders_services=orders_service_map)
     managed_execution_creation_params = ManagedExecutionCreationParams(
@@ -139,9 +142,13 @@ def test_managed_execution_succeeds_when_brokerage_order_executes(
     assert managed_execution.current_order_status == OrderStatus.EXECUTED
     assert managed_execution.current_brokerage_order_id == order_id
     mock_order_service.cancel_order.assert_not_called()
-    captured = capsys.readouterr()
-    assert "Error occurred" not in captured.out
-    assert captured.err == ""
+    _assert_no_error_logs(caplog)
+    finished_logs = _logs_for(caplog, "managed_execution_worker_finished")
+    assert finished_logs
+    assert finished_logs[-1].moex_id == create_managed_execution_response.managed_execution_id
+    assert finished_logs[-1].brokerage == Brokerage.ETRADE.value
+    assert finished_logs[-1].account_ref == "account:_123"
+    assert not hasattr(finished_logs[-1], "account_id")
 
 
 @pytest.mark.functional
@@ -151,7 +158,7 @@ def test_worker_signals_initial_order_ready_after_order_state_is_recorded(
     order: Order,
     quotes_service_map: dict[Brokerage, QuotesService],
     orders_service_map: dict[Brokerage, OrderService],
-    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ):
     # Given
     # A worker creating the first brokerage order for a managed execution.
@@ -192,9 +199,7 @@ def test_worker_signals_initial_order_ready_after_order_state_is_recorded(
     assert managed_execution.current_brokerage_order_id == order_id
     assert managed_execution.current_order_status == OrderStatus.EXECUTED
     assert managed_execution.status == ManagedExecutionStatus.EXECUTED
-    captured = capsys.readouterr()
-    assert "Error occurred" not in captured.out
-    assert captured.err == ""
+    _assert_no_error_logs(caplog)
 
 
 @pytest.mark.functional
@@ -203,7 +208,7 @@ def test_cancel_request_does_not_change_executed_managed_execution(
     order: Order,
     quotes_service_map: dict[Brokerage, QuotesService],
     orders_service_map: dict[Brokerage, OrderService],
-    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ):
     # Given
     # A managed execution that reaches a terminal EXECUTED state before cancellation.
@@ -239,9 +244,7 @@ def test_cancel_request_does_not_change_executed_managed_execution(
     mock_order_service.cancel_order.assert_not_called()
     assert cancel_managed_execution_response.managed_execution.status == ManagedExecutionStatus.EXECUTED
     assert cancel_managed_execution_response.managed_execution.current_order_status == OrderStatus.EXECUTED
-    captured = capsys.readouterr()
-    assert "Error occurred" not in captured.out
-    assert captured.err == ""
+    _assert_no_error_logs(caplog)
 
 
 @pytest.mark.functional
@@ -251,7 +254,7 @@ def test_worker_treats_rejected_order_as_executed_when_it_is_found_in_executed_o
     order: Order,
     quotes_service_map: dict[Brokerage, QuotesService],
     orders_service_map: dict[Brokerage, OrderService],
-    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ):
     # Given
     # A brokerage order read that says rejected even though the same order is in the executed list.
@@ -301,9 +304,7 @@ def test_worker_treats_rejected_order_as_executed_when_it_is_found_in_executed_o
     mock_order_service.modify_order.assert_not_called()
     assert managed_execution.status == ManagedExecutionStatus.EXECUTED
     assert managed_execution.current_order_status == OrderStatus.EXECUTED
-    captured = capsys.readouterr()
-    assert "Error occurred" not in captured.out
-    assert captured.err == ""
+    _assert_no_error_logs(caplog)
 
 
 @pytest.mark.functional
@@ -313,7 +314,7 @@ def test_worker_fails_rejected_order_when_it_is_not_found_in_executed_orders(
     order: Order,
     quotes_service_map: dict[Brokerage, QuotesService],
     orders_service_map: dict[Brokerage, OrderService],
-    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ):
     # Given
     # A brokerage order that is rejected and absent from the executed order list.
@@ -352,9 +353,55 @@ def test_worker_fails_rejected_order_when_it_is_not_found_in_executed_orders(
     mock_order_service.modify_order.assert_not_called()
     assert managed_execution.status == ManagedExecutionStatus.FAILED
     assert managed_execution.current_order_status == OrderStatus.REJECTED
-    captured = capsys.readouterr()
-    assert "Error occurred" not in captured.out
-    assert captured.err == ""
+    _assert_no_error_logs(caplog)
+
+
+@pytest.mark.functional
+def test_worker_logs_failure_context_when_broker_read_fails(
+    account_id: str,
+    order_id: str,
+    order: Order,
+    quotes_service_map: dict[Brokerage, QuotesService],
+    orders_service_map: dict[Brokerage, OrderService],
+    caplog: pytest.LogCaptureFixture,
+):
+    # Given
+    # A worker whose brokerage order read fails after the initial order is placed.
+    caplog.set_level(logging.INFO, logger=moex_service_module.__name__)
+    managed_execution = ManagedExecution(
+        brokerage=Brokerage.ETRADE,
+        account_id=account_id,
+        original_order=order,
+        status=ManagedExecutionStatus.PRE_SUBMISSION,
+    )
+    worker = ManagedExecutionWorker(
+        moex=managed_execution,
+        moex_id="moex-1",
+        quotes_services=quotes_service_map,
+        orders_services=orders_service_map,
+    )
+    mock_order_service = orders_service_map[Brokerage.ETRADE]
+    mock_order_service.get_order = MagicMock(side_effect=RuntimeError("broker read failed"))
+
+    # When
+    # The worker attempts to read the brokerage order.
+    worker()
+
+    # Then
+    # The managed execution fails and the worker emits one structured failure log.
+    mock_order_service.get_order.assert_called_once_with(
+        GetOrderRequest(account_id=account_id, order_id=order_id)
+    )
+    assert managed_execution.status == ManagedExecutionStatus.FAILED
+    failure_logs = _logs_for(caplog, "managed_execution_worker_failed")
+    assert len(failure_logs) == 1
+    assert failure_logs[0].levelno == logging.ERROR
+    assert failure_logs[0].moex_id == "moex-1"
+    assert failure_logs[0].brokerage_order_id == order_id
+    assert failure_logs[0].managed_execution_status == ManagedExecutionStatus.FAILED.value
+    assert failure_logs[0].error_type == RuntimeError.__name__
+    assert failure_logs[0].account_ref == "account:_123"
+    assert not hasattr(failure_logs[0], "account_id")
 
 
 @pytest.mark.functional
@@ -364,7 +411,7 @@ def test_worker_stops_before_next_broker_poll_after_cancellation(
     order: Order,
     quotes_service_map: dict[Brokerage, QuotesService],
     orders_service_map: dict[Brokerage, OrderService],
-    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ):
     # Given
     # A worker that has placed a replacement order and then receives a cancellation request.
@@ -415,9 +462,7 @@ def test_worker_stops_before_next_broker_poll_after_cancellation(
     )
     assert managed_execution.current_brokerage_order_id == replacement_order_id
     assert managed_execution.status == ManagedExecutionStatus.CANCEL_REQUESTED
-    captured = capsys.readouterr()
-    assert "Error occurred" not in captured.out
-    assert captured.err == ""
+    _assert_no_error_logs(caplog)
 
 
 @pytest.mark.functional
@@ -427,7 +472,7 @@ def test_worker_cancellation_interrupts_wait_before_next_broker_poll(
     order: Order,
     quotes_service_map: dict[Brokerage, QuotesService],
     orders_service_map: dict[Brokerage, OrderService],
-    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ):
     # Given
     # A worker that would otherwise wait before checking a replacement order again.
@@ -485,9 +530,7 @@ def test_worker_cancellation_interrupts_wait_before_next_broker_poll(
     mock_order_service.modify_order.assert_called_once()
     assert managed_execution.current_brokerage_order_id == replacement_order_id
     assert managed_execution.status == ManagedExecutionStatus.CANCEL_REQUESTED
-    captured = capsys.readouterr()
-    assert "Error occurred" not in captured.out
-    assert captured.err == ""
+    _assert_no_error_logs(caplog)
 
 
 # TODO: Place into a separate class later
@@ -557,3 +600,15 @@ def _assert_executed_orders_were_checked(mock_order_service: OrderService, accou
     list_orders_request = mock_order_service.list_orders.call_args.args[0]
     assert list_orders_request.account_id == account_id
     assert list_orders_request.status == OrderStatus.EXECUTED
+
+
+def _assert_no_error_logs(caplog: pytest.LogCaptureFixture) -> None:
+    assert [record for record in caplog.records if record.levelno >= logging.ERROR] == []
+
+
+def _logs_for(caplog: pytest.LogCaptureFixture, event_name: str) -> list[logging.LogRecord]:
+    return [
+        record
+        for record in caplog.records
+        if record.name == moex_service_module.__name__ and record.getMessage() == event_name
+    ]


### PR DESCRIPTION
## Summary
- add explicit managed execution transition events and validation helpers
- route MOEX worker and cancellation status updates through the transition policy
- document the enforced transition policy and terminal-state immutability

## Ticket
- https://linear.app/fianchetto-labs/issue/FIA-163/define-managed-execution-state-machine-transitions

## Verification
- .venv/bin/python -m nox -s test -- tests/common/test_managed_execution_status.py tests/moex/worker/eviction/test_moex_eviction.py
  - 58 passed

## Scope notes
- Leaves structured logging/print cleanup for FIA-167.
- Leaves runtime dependency-mode config hardening for FIA-142.