### PR TITLE
FIA-142: Add explicit MOEX dependency mode configuration

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -85,6 +85,11 @@ Important runtime configuration:
 | `TRADEBOT_ORDERS_SERVICE_URL` | Tells MOEX where the orders service lives in HTTP mode. |
 | `TRADEBOT_QUOTES_SERVICE_URL` | Tells MOEX where the quotes service lives in HTTP mode. |
 
+`TRADEBOT_MOEX_SERVICE_ADAPTER_MODE` defaults to `local` for simple developer
+startup. When it is set to `http`, both `TRADEBOT_ORDERS_SERVICE_URL` and
+`TRADEBOT_QUOTES_SERVICE_URL` must be set explicitly so containerized startup
+does not silently point at localhost.
+
 ## Troubleshooting
 
 - If a Nox Docker command skips, confirm `TRADEBOT_RUN_SERVICE_TESTS=1` is set

--- a/docs/service-ports.md
+++ b/docs/service-ports.md
@@ -40,7 +40,11 @@ The environment variable names are deployment-neutral:
 - `TRADEBOT_ORDERS_SERVICE_URL`
 - `TRADEBOT_QUOTES_SERVICE_URL`
 
-Code defaults point at local development ports. Docker Compose and Kubernetes should override those values with the right service DNS names for that environment.
+Low-level adapter defaults point at local development ports for direct
+construction. MOEX startup is stricter: `TRADEBOT_MOEX_SERVICE_ADAPTER_MODE`
+defaults to `local`, and when it is explicitly set to `http`, both service URL
+environment variables must be set. Docker Compose and Kubernetes should provide
+the right service DNS names for that environment.
 
 HTTP adapters should construct URLs using the route path values required by the target service. FastAPI handlers do not need to accept every path value when the handler only needs the parsed Pydantic request body.
 

--- a/src/fianchetto_tradebot/server/common/service/adapters/__init__.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/__init__.py
@@ -8,8 +8,10 @@ from fianchetto_tradebot.server.common.service.adapters.http_service_adapter_con
     DEFAULT_QUOTES_SERVICE_URL,
     ORDERS_SERVICE_URL_ENV_VAR,
     QUOTES_SERVICE_URL_ENV_VAR,
+    HttpServiceAdapterConfigurationError,
     HttpServiceAdapterConfig,
     load_http_service_adapter_config,
+    load_required_http_service_adapter_config,
 )
 from fianchetto_tradebot.server.common.service.adapters.http_service_adapter_error import HttpServiceAdapterError
 from fianchetto_tradebot.server.common.service.adapters.local_brokerage_service_adapters import (
@@ -25,6 +27,7 @@ __all__ = [
     "DEFAULT_QUOTES_SERVICE_URL",
     "HttpOrderServiceAdapter",
     "HttpQuoteServiceAdapter",
+    "HttpServiceAdapterConfigurationError",
     "HttpServiceAdapterConfig",
     "HttpServiceAdapterError",
     "LocalOrderServiceAdapter",
@@ -36,4 +39,5 @@ __all__ = [
     "build_http_service_adapters",
     "build_local_service_adapters",
     "load_http_service_adapter_config",
+    "load_required_http_service_adapter_config",
 ]

--- a/src/fianchetto_tradebot/server/common/service/adapters/http_service_adapter_config.py
+++ b/src/fianchetto_tradebot/server/common/service/adapters/http_service_adapter_config.py
@@ -14,8 +14,65 @@ class HttpServiceAdapterConfig:
     quotes_base_url: str = DEFAULT_QUOTES_SERVICE_URL
 
 
+class HttpServiceAdapterConfigurationError(ValueError):
+    pass
+
+
 def load_http_service_adapter_config(env: Mapping[str, str] = os.environ) -> HttpServiceAdapterConfig:
     return HttpServiceAdapterConfig(
-        orders_base_url=env.get(ORDERS_SERVICE_URL_ENV_VAR, DEFAULT_ORDERS_SERVICE_URL),
-        quotes_base_url=env.get(QUOTES_SERVICE_URL_ENV_VAR, DEFAULT_QUOTES_SERVICE_URL),
+        orders_base_url=_service_url_or_default(
+            env,
+            ORDERS_SERVICE_URL_ENV_VAR,
+            DEFAULT_ORDERS_SERVICE_URL,
+        ),
+        quotes_base_url=_service_url_or_default(
+            env,
+            QUOTES_SERVICE_URL_ENV_VAR,
+            DEFAULT_QUOTES_SERVICE_URL,
+        ),
     )
+
+
+def load_required_http_service_adapter_config(env: Mapping[str, str] = os.environ) -> HttpServiceAdapterConfig:
+    orders_base_url = _service_url_or_none(env, ORDERS_SERVICE_URL_ENV_VAR)
+    quotes_base_url = _service_url_or_none(env, QUOTES_SERVICE_URL_ENV_VAR)
+    missing_env_vars = [
+        env_var
+        for env_var, value in (
+            (ORDERS_SERVICE_URL_ENV_VAR, orders_base_url),
+            (QUOTES_SERVICE_URL_ENV_VAR, quotes_base_url),
+        )
+        if value is None
+    ]
+
+    if missing_env_vars:
+        raise HttpServiceAdapterConfigurationError(
+            "HTTP service adapter mode requires explicit service URLs: "
+            f"{', '.join(missing_env_vars)}. "
+            "Set them for deployed service dependencies or use local mode."
+        )
+
+    return HttpServiceAdapterConfig(
+        orders_base_url=orders_base_url,
+        quotes_base_url=quotes_base_url,
+    )
+
+
+def _service_url_or_default(
+    env: Mapping[str, str],
+    env_var: str,
+    default: str,
+) -> str:
+    return _service_url_or_none(env, env_var) or default
+
+
+def _service_url_or_none(env: Mapping[str, str], env_var: str) -> str | None:
+    value = env.get(env_var)
+    if value is None:
+        return None
+
+    stripped_value = value.strip()
+    if not stripped_value:
+        return None
+
+    return stripped_value

--- a/src/fianchetto_tradebot/server/moex/serving/moex_rest_service.py
+++ b/src/fianchetto_tradebot/server/moex/serving/moex_rest_service.py
@@ -1,5 +1,7 @@
+import logging
 import os
 from datetime import datetime
+from enum import StrEnum
 from typing import Mapping
 
 from fastapi import FastAPI
@@ -26,19 +28,39 @@ from fianchetto_tradebot.server.common.service.adapters import (
     ServiceAdapters,
     build_http_service_adapters,
     build_local_service_adapters,
-    load_http_service_adapter_config,
+    load_required_http_service_adapter_config,
 )
 from fianchetto_tradebot.server.common.service.ports import OrderServicePort, QuoteServicePort
 from fianchetto_tradebot.server.common.service.rest_service import RestService, ETRADE_ONLY_BROKERAGE_CONFIG
 from fianchetto_tradebot.server.common.service.service_key import ServiceKey
 
 MOEX_SERVICE_ADAPTER_MODE_ENV_VAR = "TRADEBOT_MOEX_SERVICE_ADAPTER_MODE"
-LOCAL_SERVICE_ADAPTER_MODE = "local"
-HTTP_SERVICE_ADAPTER_MODE = "http"
+
+
+class MoexServiceAdapterMode(StrEnum):
+    LOCAL = "local"
+    HTTP = "http"
+
+
+LOCAL_SERVICE_ADAPTER_MODE = MoexServiceAdapterMode.LOCAL.value
+HTTP_SERVICE_ADAPTER_MODE = MoexServiceAdapterMode.HTTP.value
 
 JAN_1_2024 = datetime(2024,1,1).date()
 DEFAULT_START_DATE = JAN_1_2024
 DEFAULT_COUNT = 100
+
+logger = logging.getLogger(__name__)
+
+
+def _load_moex_service_adapter_mode(env: Mapping[str, str]) -> MoexServiceAdapterMode:
+    adapter_mode = env.get(MOEX_SERVICE_ADAPTER_MODE_ENV_VAR, LOCAL_SERVICE_ADAPTER_MODE).strip().lower()
+    try:
+        return MoexServiceAdapterMode(adapter_mode)
+    except ValueError as exc:
+        raise ValueError(
+            f"{MOEX_SERVICE_ADAPTER_MODE_ENV_VAR} must be "
+            f"'{LOCAL_SERVICE_ADAPTER_MODE}' or '{HTTP_SERVICE_ADAPTER_MODE}'"
+        ) from exc
 
 
 class MoexRestService(RestService):
@@ -78,18 +100,17 @@ class MoexRestService(RestService):
 
     def _build_service_adapters(self, env: Mapping[str, str] | None = None) -> ServiceAdapters:
         env = os.environ if env is None else env
-        adapter_mode = env.get(MOEX_SERVICE_ADAPTER_MODE_ENV_VAR, LOCAL_SERVICE_ADAPTER_MODE).strip().lower()
-        if adapter_mode == LOCAL_SERVICE_ADAPTER_MODE:
+        adapter_mode = _load_moex_service_adapter_mode(env)
+        logger.info("Building MOEX service adapters in %s mode", adapter_mode.value)
+
+        if adapter_mode == MoexServiceAdapterMode.LOCAL:
             return build_local_service_adapters(self.connectors)
-        if adapter_mode == HTTP_SERVICE_ADAPTER_MODE:
+        if adapter_mode == MoexServiceAdapterMode.HTTP:
             return build_http_service_adapters(
                 self.connectors.keys(),
-                config=load_http_service_adapter_config(env),
+                config=load_required_http_service_adapter_config(env),
             )
-        raise ValueError(
-            f"{MOEX_SERVICE_ADAPTER_MODE_ENV_VAR} must be "
-            f"'{LOCAL_SERVICE_ADAPTER_MODE}' or '{HTTP_SERVICE_ADAPTER_MODE}'"
-        )
+        raise AssertionError(f"Unhandled MOEX service adapter mode: {adapter_mode}")
 
     def list_managed_executions(self, brokerage: str, account_id: str):
         # TODO - FIA-114:

--- a/tests/common/service/test_http_service_adapters.py
+++ b/tests/common/service/test_http_service_adapters.py
@@ -34,12 +34,14 @@ from fianchetto_tradebot.server.common.service.adapters import (
     DEFAULT_QUOTES_SERVICE_URL,
     ORDERS_SERVICE_URL_ENV_VAR,
     QUOTES_SERVICE_URL_ENV_VAR,
+    HttpServiceAdapterConfigurationError,
     HttpOrderServiceAdapter,
     HttpQuoteServiceAdapter,
     HttpServiceAdapterError,
     ServiceAdapters,
     build_http_service_adapters,
     load_http_service_adapter_config,
+    load_required_http_service_adapter_config,
 )
 
 
@@ -102,6 +104,41 @@ def test_http_adapter_config_defaults_to_local_service_urls():
 
     assert config.orders_base_url == DEFAULT_ORDERS_SERVICE_URL
     assert config.quotes_base_url == DEFAULT_QUOTES_SERVICE_URL
+
+
+def test_required_http_adapter_config_rejects_missing_service_urls():
+    with pytest.raises(HttpServiceAdapterConfigurationError) as exc_info:
+        load_required_http_service_adapter_config({})
+
+    message = str(exc_info.value)
+    assert ORDERS_SERVICE_URL_ENV_VAR in message
+    assert QUOTES_SERVICE_URL_ENV_VAR in message
+
+
+def test_required_http_adapter_config_rejects_blank_service_url():
+    with pytest.raises(HttpServiceAdapterConfigurationError) as exc_info:
+        load_required_http_service_adapter_config(
+            {
+                ORDERS_SERVICE_URL_ENV_VAR: "http://orders:8080",
+                QUOTES_SERVICE_URL_ENV_VAR: " ",
+            }
+        )
+
+    message = str(exc_info.value)
+    assert ORDERS_SERVICE_URL_ENV_VAR not in message
+    assert QUOTES_SERVICE_URL_ENV_VAR in message
+
+
+def test_required_http_adapter_config_uses_explicit_service_urls():
+    config = load_required_http_service_adapter_config(
+        {
+            ORDERS_SERVICE_URL_ENV_VAR: " http://orders:8080 ",
+            QUOTES_SERVICE_URL_ENV_VAR: "http://quotes:8081",
+        }
+    )
+
+    assert config.orders_base_url == "http://orders:8080"
+    assert config.quotes_base_url == "http://quotes:8081"
 
 
 def test_build_http_service_adapters_creates_port_adapters_from_shared_container():

--- a/tests/common/service/test_moex_rest_service_composition.py
+++ b/tests/common/service/test_moex_rest_service_composition.py
@@ -1,3 +1,7 @@
+import logging
+
+import pytest
+
 from fianchetto_tradebot.common_models.brokerage.brokerage import Brokerage
 from fianchetto_tradebot.common_models.managed_executions.get_managed_execution_request import (
     GetManagedExecutionRequest,
@@ -5,7 +9,12 @@ from fianchetto_tradebot.common_models.managed_executions.get_managed_execution_
 from fianchetto_tradebot.common_models.managed_executions.get_managed_execution_response import (
     GetManagedExecutionResponse,
 )
-from fianchetto_tradebot.server.common.service.adapters import ServiceAdapters
+from fianchetto_tradebot.server.common.service.adapters import (
+    HttpServiceAdapterConfigurationError,
+    ORDERS_SERVICE_URL_ENV_VAR,
+    QUOTES_SERVICE_URL_ENV_VAR,
+    ServiceAdapters,
+)
 from fianchetto_tradebot.server.moex.serving import moex_rest_service
 from fianchetto_tradebot.server.moex.serving.moex_rest_service import (
     HTTP_SERVICE_ADAPTER_MODE,
@@ -29,7 +38,7 @@ class _FakeMoexService:
         return self.response
 
 
-def test_moex_service_uses_local_adapters_by_default(monkeypatch):
+def test_moex_service_uses_local_adapters_by_default(monkeypatch, caplog):
     service = object.__new__(MoexRestService)
     service.connectors = {Brokerage.ETRADE: _FakeConnector()}
     expected_adapters = ServiceAdapters(order_services={}, quote_services={})
@@ -45,19 +54,22 @@ def test_moex_service_uses_local_adapters_by_default(monkeypatch):
         build_local_service_adapters,
     )
 
-    assert service._build_service_adapters(env={}) is expected_adapters
+    with caplog.at_level(logging.INFO, logger=moex_rest_service.__name__):
+        assert service._build_service_adapters(env={}) is expected_adapters
+
     assert calls == [service.connectors]
+    assert "local mode" in caplog.text
 
 
-def test_moex_service_can_use_http_adapters_from_environment(monkeypatch):
+def test_moex_service_can_use_http_adapters_from_environment(monkeypatch, caplog):
     service = object.__new__(MoexRestService)
     service.connectors = {Brokerage.ETRADE: _FakeConnector()}
     expected_adapters = ServiceAdapters(order_services={}, quote_services={})
     calls = []
     env = {
         MOEX_SERVICE_ADAPTER_MODE_ENV_VAR: HTTP_SERVICE_ADAPTER_MODE,
-        "TRADEBOT_ORDERS_SERVICE_URL": "http://orders:8080",
-        "TRADEBOT_QUOTES_SERVICE_URL": "http://quotes:8081",
+        ORDERS_SERVICE_URL_ENV_VAR: "http://orders:8080",
+        QUOTES_SERVICE_URL_ENV_VAR: "http://quotes:8081",
     }
 
     def build_http_service_adapters(brokerages, config):
@@ -70,12 +82,27 @@ def test_moex_service_can_use_http_adapters_from_environment(monkeypatch):
         build_http_service_adapters,
     )
 
-    assert service._build_service_adapters(env=env) is expected_adapters
+    with caplog.at_level(logging.INFO, logger=moex_rest_service.__name__):
+        assert service._build_service_adapters(env=env) is expected_adapters
 
     brokerages, config = calls[0]
     assert brokerages == [Brokerage.ETRADE]
     assert config.orders_base_url == "http://orders:8080"
     assert config.quotes_base_url == "http://quotes:8081"
+    assert "http mode" in caplog.text
+
+
+def test_moex_service_rejects_http_mode_without_explicit_service_urls():
+    service = object.__new__(MoexRestService)
+    service.connectors = {Brokerage.ETRADE: _FakeConnector()}
+
+    with pytest.raises(HttpServiceAdapterConfigurationError) as exc_info:
+        service._build_service_adapters(env={MOEX_SERVICE_ADAPTER_MODE_ENV_VAR: HTTP_SERVICE_ADAPTER_MODE})
+
+    message = str(exc_info.value)
+    assert ORDERS_SERVICE_URL_ENV_VAR in message
+    assert QUOTES_SERVICE_URL_ENV_VAR in message
+    assert "local mode" in message
 
 
 def test_moex_service_rejects_unknown_adapter_mode():


### PR DESCRIPTION
Ticket:
- https://linear.app/fianchetto-labs/issue/FIA-142/add-runtime-wiring-for-local-vs-http-service-dependency-mode

Summary:
- Added a strict HTTP service adapter config loader for startup composition.
- Kept local mode as the MOEX default while requiring explicit orders/quotes service URLs when HTTP mode is selected.
- Logged the selected MOEX dependency mode during adapter construction.
- Documented the HTTP-mode env var precedence in deployment/service-port docs.

Verification:
- `.venv/bin/python -m nox -s test -- tests/common/service/test_moex_rest_service_composition.py tests/common/service/test_http_service_adapters.py`
- Result: 18 passed.

Scope exclusions:
- Did not touch MOEX worker logging; that belongs to FIA-167.
- Did not touch managed-execution status/state-machine files; that belongs to FIA-163.
- Did not change Docker Compose files because existing Compose env already provides the required HTTP service URLs.

Residual risk:
- Low-level HTTP adapter construction still has localhost defaults for direct dev/test construction; MOEX HTTP startup now uses the strict loader so deployed HTTP mode fails fast instead of silently using localhost.