### PR TITLE
FIA-171: Add ETrade credential provider interface

### DIFF
--- a/src/fianchetto_tradebot/server/common/brokerage/etrade/credentials.py
+++ b/src/fianchetto_tradebot/server/common/brokerage/etrade/credentials.py
@@ -1,0 +1,209 @@
+import datetime
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Protocol
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_CREDENTIAL_FIELDS = (
+    "consumer_key",
+    "consumer_secret",
+    "access_token",
+    "access_token_secret",
+    "base_url",
+)
+OPTIONAL_CREDENTIAL_FIELDS = (
+    "request_token",
+    "request_token_secret",
+)
+
+
+@dataclass(frozen=True, repr=False)
+class ETradeConnectionCredentials:
+    consumer_key: str
+    consumer_secret: str
+    access_token: str
+    access_token_secret: str
+    request_token: str | None
+    request_token_secret: str | None
+    base_url: str
+
+    def __repr__(self) -> str:
+        return (
+            "ETradeConnectionCredentials("
+            "consumer_key=<redacted>, "
+            "consumer_secret=<redacted>, "
+            "access_token=<redacted>, "
+            "access_token_secret=<redacted>, "
+            "request_token=<redacted>, "
+            "request_token_secret=<redacted>, "
+            f"base_url={self.base_url!r})"
+        )
+
+    @classmethod
+    def from_mapping(cls, credentials: Mapping[str, object]) -> "ETradeConnectionCredentials":
+        if not isinstance(credentials, Mapping):
+            raise ValueError("E*Trade connection credentials must be a JSON object")
+
+        normalized_credentials = dict(credentials)
+        for field in REQUIRED_CREDENTIAL_FIELDS:
+            _require_non_empty_string(normalized_credentials, field)
+
+        for field in OPTIONAL_CREDENTIAL_FIELDS:
+            if field not in normalized_credentials:
+                raise ValueError(f"E*Trade connection credentials must include {field}")
+            value = normalized_credentials[field]
+            if value is not None:
+                _require_non_empty_string(normalized_credentials, field)
+
+        return cls(
+            consumer_key=normalized_credentials["consumer_key"],
+            consumer_secret=normalized_credentials["consumer_secret"],
+            access_token=normalized_credentials["access_token"],
+            access_token_secret=normalized_credentials["access_token_secret"],
+            request_token=normalized_credentials["request_token"],
+            request_token_secret=normalized_credentials["request_token_secret"],
+            base_url=normalize_etrade_base_url(normalized_credentials["base_url"], "base_url"),
+        )
+
+    def to_mapping(self) -> dict[str, str | None]:
+        return {
+            "consumer_key": self.consumer_key,
+            "consumer_secret": self.consumer_secret,
+            "access_token": self.access_token,
+            "access_token_secret": self.access_token_secret,
+            "request_token": self.request_token,
+            "request_token_secret": self.request_token_secret,
+            "base_url": self.base_url,
+        }
+
+
+class ETradeCredentialProvider(Protocol):
+    def load(self) -> ETradeConnectionCredentials | None:
+        """Return valid connection credentials, or None when the provider has no usable record."""
+
+    def store(self, credentials: ETradeConnectionCredentials) -> None:
+        """Persist connection credentials."""
+
+    def load_base_url(self) -> str | None:
+        """Return a standalone base URL fallback, or None when absent or expired."""
+
+    def store_base_url(self, base_url: str) -> None:
+        """Persist a standalone base URL fallback."""
+
+
+class ETradeFileCredentialProvider:
+    def __init__(
+            self,
+            credentials_file: str | os.PathLike[str],
+            base_url_file: str | os.PathLike[str],
+            max_age: datetime.timedelta):
+        self.credentials_file = Path(credentials_file)
+        self.base_url_file = Path(base_url_file)
+        self.max_age = max_age
+
+    def load(self) -> ETradeConnectionCredentials | None:
+        if not is_file_still_valid(self.credentials_file, max_age=self.max_age):
+            return None
+        return ETradeConnectionCredentials.from_mapping(_deserialize_json_object(self.credentials_file))
+
+    def store(self, credentials: ETradeConnectionCredentials) -> None:
+        _serialize_json_object(credentials.to_mapping(), self.credentials_file)
+
+    def load_base_url(self) -> str | None:
+        if not is_file_still_valid(self.base_url_file, max_age=self.max_age):
+            return None
+        return normalize_etrade_base_url(_deserialize_json_value(self.base_url_file), "base_url")
+
+    def store_base_url(self, base_url: str) -> None:
+        _serialize_json_value(normalize_etrade_base_url(base_url, "base_url"), self.base_url_file)
+
+
+def is_file_still_valid(input_file: str | os.PathLike[str], max_age: datetime.timedelta) -> bool:
+    path = Path(input_file)
+    if not path.exists():
+        logger.info("File %s does not exist", path)
+        return False
+
+    last_modified_unix_timestamp = os.path.getmtime(path)
+    last_modified = datetime.datetime.fromtimestamp(last_modified_unix_timestamp)
+    now = datetime.datetime.now()
+
+    if now - last_modified > max_age:
+        return False
+
+    return True
+
+
+def normalize_etrade_base_url(raw_base_url: object, source: str) -> str:
+    if not isinstance(raw_base_url, str) or not raw_base_url.strip():
+        raise ValueError(f"E*Trade {source} must be a non-empty URL")
+
+    base_url = raw_base_url.strip().rstrip("/")
+    parsed_url = urlparse(base_url)
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+        raise ValueError(f"E*Trade {source} must be an http(s) URL")
+
+    return base_url
+
+
+def serialize_connection_credentials(
+        credentials: Mapping[str, object],
+        output_file: str | os.PathLike[str]) -> None:
+    credential_document = ETradeConnectionCredentials.from_mapping(credentials)
+    _serialize_json_object(credential_document.to_mapping(), output_file)
+
+
+def deserialize_connection_credentials(input_file: str | os.PathLike[str]) -> dict[str, object]:
+    return _deserialize_json_object(input_file)
+
+
+def serialize_json_value(value: object, output_file: str | os.PathLike[str]) -> None:
+    _serialize_json_value(value, output_file)
+
+
+def deserialize_json_value(input_file: str | os.PathLike[str]) -> object:
+    return _deserialize_json_value(input_file)
+
+
+def _require_non_empty_string(credentials: Mapping[str, object], field: str) -> None:
+    if field not in credentials:
+        raise ValueError(f"E*Trade connection credentials must include {field}")
+    value = credentials[field]
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"E*Trade connection credential {field} must be a non-empty string")
+
+
+def _serialize_json_value(value: object, output_file: str | os.PathLike[str]) -> None:
+    _serialize_json_object({"value": value}, output_file)
+
+
+def _deserialize_json_value(input_file: str | os.PathLike[str]) -> object:
+    with open(Path(input_file)) as f:
+        return json.load(f)["value"]
+
+
+def _serialize_json_object(value: Mapping[str, object], output_file: str | os.PathLike[str]) -> None:
+    _ensure_private_parent(output_file)
+    with open(Path(output_file), "w") as f:
+        json.dump(value, f)
+    _chmod_private(output_file)
+
+
+def _deserialize_json_object(input_file: str | os.PathLike[str]) -> dict[str, object]:
+    with open(Path(input_file)) as f:
+        return json.load(f)
+
+
+def _ensure_private_parent(output_file: str | os.PathLike[str]) -> None:
+    parent_dir = Path(output_file).parent
+    parent_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(parent_dir, 0o700)
+
+
+def _chmod_private(output_file: str | os.PathLike[str]) -> None:
+    os.chmod(output_file, 0o600)

--- a/src/fianchetto_tradebot/server/common/brokerage/etrade/etrade_connector.py
+++ b/src/fianchetto_tradebot/server/common/brokerage/etrade/etrade_connector.py
@@ -1,17 +1,24 @@
 import configparser
 import datetime
-import json
-import logging
 import os
 import webbrowser
-from pathlib import Path
 from typing import Mapping
-from urllib.parse import urlparse
 
 from aioauth_client import OAuth1Client
 from rauth import OAuth1Service, OAuth1Session
 
 from fianchetto_tradebot.server.common.brokerage.connector import Connector
+from fianchetto_tradebot.server.common.brokerage.etrade.credentials import (
+    ETradeConnectionCredentials,
+    ETradeCredentialProvider,
+    ETradeFileCredentialProvider,
+    deserialize_connection_credentials,
+    deserialize_json_value,
+    is_file_still_valid,
+    normalize_etrade_base_url,
+    serialize_connection_credentials,
+    serialize_json_value,
+)
 
 config = configparser.ConfigParser()
 
@@ -31,25 +38,11 @@ DEFAULT_ETRADE_BASE_URL_FILE = os.path.join(BROKERAGE_STATE_DIR, "base_url.json"
 ETRADE_API_BASE_URL_ENV_VAR = "TRADEBOT_ETRADE_API_BASE_URL"
 ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR = "TRADEBOT_ETRADE_CACHE_MAX_AGE_SECONDS"
 DEFAULT_CACHE_MAX_AGE_SECONDS = 60 * 60
-REQUIRED_CREDENTIAL_FIELDS = (
-    "consumer_key",
-    "consumer_secret",
-    "access_token",
-    "access_token_secret",
-    "base_url",
-)
-OPTIONAL_CREDENTIAL_FIELDS = (
-    "request_token",
-    "request_token_secret",
-)
-
 # For debugging
 REQUEST_TOKEN_FILE = os.path.join(BROKERAGE_STATE_DIR, "request_token.json")
 REQUEST_TOKEN_SECRET_FILE = os.path.join(BROKERAGE_STATE_DIR, "request_token_secret.json")
 OAUTH_TOKEN_FILE = os.path.join(BROKERAGE_STATE_DIR, "oauth_token.json")
 OAUTH_TOKEN_SECRET_FILE = os.path.join(BROKERAGE_STATE_DIR, "oauth_token_secret.json")
-
-logger = logging.getLogger(__name__)
 
 
 class ETradeConnector(Connector):
@@ -59,7 +52,8 @@ class ETradeConnector(Connector):
             session_file=DEFAULT_SESSION_FILE,
             async_session_file=DEFAULT_ASYNC_SESSION_FILE,
             base_url_file=DEFAULT_ETRADE_BASE_URL_FILE,
-            env: Mapping[str, str] | None = None):
+            env: Mapping[str, str] | None = None,
+            credential_provider: ETradeCredentialProvider | None = None):
         self.brokerage = BROKERAGE_NAME
         self.config_file = config_file
         self.env = env if env is not None else os.environ
@@ -68,12 +62,13 @@ class ETradeConnector(Connector):
         self.session_file = session_file
         self.async_session_file = async_session_file
         self.base_url_file = base_url_file
+        self.credential_provider = credential_provider or self._default_credential_provider()
         self.session, self.async_session, self.base_url = self.load_connection()
 
     def load_base_url(self) -> str:
         credentials = self._load_valid_connection_credentials()
         if credentials:
-            return self._resolve_base_url(credentials_base_url=credentials["base_url"])
+            return self._resolve_base_url(credentials_base_url=credentials.base_url)
 
         standalone_base_url = self._load_valid_standalone_base_url()
         if standalone_base_url:
@@ -85,7 +80,7 @@ class ETradeConnector(Connector):
         credentials = self._load_valid_connection_credentials()
         if credentials:
             base_url = self._resolve_base_url(
-                credentials_base_url=credentials["base_url"],
+                credentials_base_url=credentials.base_url,
             )
             return ETradeConnector._build_connection_from_credentials(credentials, base_url)
 
@@ -105,21 +100,23 @@ class ETradeConnector(Connector):
             return ETradeConnector._normalize_base_url(standalone_base_url, "base_url")
         return None
 
-    def _load_valid_connection_credentials(self) -> dict | None:
-        if not ETradeConnector.is_file_still_valid(
-                self.credentials_file,
-                max_age=self._cache_max_age()):
-            return None
-        return ETradeConnector._validate_connection_credentials(
-            ETradeConnector._deserialize_connection_credentials(self.credentials_file)
-        )
+    def _load_valid_connection_credentials(self) -> ETradeConnectionCredentials | None:
+        return self._credential_provider().load()
 
     def _load_valid_standalone_base_url(self) -> str | None:
-        if not ETradeConnector.is_file_still_valid(
-                self.base_url_file,
-                max_age=self._cache_max_age()):
-            return None
-        return ETradeConnector.deserialize_base_url(self.base_url_file)
+        return self._credential_provider().load_base_url()
+
+    def _credential_provider(self) -> ETradeCredentialProvider:
+        if not hasattr(self, "credential_provider"):
+            self.credential_provider = self._default_credential_provider()
+        return self.credential_provider
+
+    def _default_credential_provider(self) -> ETradeFileCredentialProvider:
+        return ETradeFileCredentialProvider(
+            credentials_file=self.credentials_file,
+            base_url_file=self.base_url_file,
+            max_age=self._cache_max_age(),
+        )
 
     def _configured_base_url(self) -> str | None:
         raw_base_url = self.env.get(ETRADE_API_BASE_URL_ENV_VAR)
@@ -221,7 +218,7 @@ class ETradeConnector(Connector):
         return session, async_session, base_url
 
     def serialize_session(self, session: OAuth1Session):
-        ETradeConnector._serialize_connection_credentials({
+        self._store_connection_credentials({
             "consumer_key": session.consumer_key,
             "consumer_secret": session.consumer_secret,
             "access_token": session.access_token,
@@ -229,7 +226,7 @@ class ETradeConnector(Connector):
             "request_token": None,
             "request_token_secret": None,
             "base_url": self.base_url,
-        }, self.credentials_file)
+        })
 
     def serialize_async_session(self, async_session: OAuth1Client):
         # Async sessions are reconstructed from the same credential document as sync sessions.
@@ -238,7 +235,7 @@ class ETradeConnector(Connector):
     def serialize_connection_credentials(self, consumer_key: str, consumer_secret: str, access_token: str,
                                          access_token_secret: str, request_token: str,
                                          request_token_secret: str, base_url: str):
-        ETradeConnector._serialize_connection_credentials({
+        self._store_connection_credentials({
             "consumer_key": consumer_key,
             "consumer_secret": consumer_secret,
             "access_token": access_token,
@@ -246,7 +243,7 @@ class ETradeConnector(Connector):
             "request_token": request_token,
             "request_token_secret": request_token_secret,
             "base_url": base_url,
-        }, self.credentials_file)
+        })
 
     def serialize_request_token(self, token: str):
         ETradeConnector._serialize_json_value(token, REQUEST_TOKEN_FILE)
@@ -262,7 +259,20 @@ class ETradeConnector(Connector):
 
     def serialize_base_url(self, base_url: str):
         base_url = ETradeConnector._normalize_base_url(base_url, "base_url")
+        if hasattr(self, "credential_provider"):
+            self.credential_provider.store_base_url(base_url)
+            return
         ETradeConnector._serialize_json_value(base_url, self.base_url_file)
+
+    def _store_connection_credentials(self, credentials: Mapping[str, object]) -> None:
+        credential_document = ETradeConnectionCredentials.from_mapping(credentials)
+        if hasattr(self, "credential_provider"):
+            self.credential_provider.store(credential_document)
+            return
+        ETradeConnector._serialize_connection_credentials(
+            credential_document.to_mapping(),
+            self.credentials_file,
+        )
 
     @staticmethod
     def deserialize_session(input=DEFAULT_SESSION_FILE) -> OAuth1Session:
@@ -297,83 +307,67 @@ class ETradeConnector(Connector):
 
     @staticmethod
     def is_file_still_valid(input, max_age=datetime.timedelta(hours=1)):
-        input_file = Path(input)
-        if not input_file.exists():
-            logger.info(f"File {input_file} does not exist")
-            return False
-
-        last_modified_unix_timestamp = os.path.getmtime(input_file)
-        last_modified = datetime.datetime.fromtimestamp(last_modified_unix_timestamp)
-        now = datetime.datetime.now()
-
-        if now - last_modified > max_age:
-            return False
-
-        return True
+        return is_file_still_valid(input, max_age=max_age)
 
     @staticmethod
     def _serialize_json_value(value, output_file):
-        ETradeConnector._ensure_private_parent(output_file)
-        with open(output_file, "w") as f:
-            json.dump({"value": value}, f)
-        ETradeConnector._chmod_private(output_file)
+        serialize_json_value(value, output_file)
 
     @staticmethod
     def _deserialize_json_value(input_file) -> str:
-        with open(Path(input_file)) as f:
-            return json.load(f)["value"]
+        return deserialize_json_value(input_file)
 
     @staticmethod
     def _serialize_connection_credentials(credentials: dict, output_file):
-        credentials = ETradeConnector._validate_connection_credentials(credentials)
-        ETradeConnector._ensure_private_parent(output_file)
-        with open(output_file, "w") as f:
-            json.dump(credentials, f)
-        ETradeConnector._chmod_private(output_file)
+        serialize_connection_credentials(credentials, output_file)
 
     @staticmethod
     def _deserialize_connection_credentials(input_file) -> dict:
-        with open(Path(input_file)) as f:
-            return json.load(f)
+        return deserialize_connection_credentials(input_file)
 
     @staticmethod
     def _build_connection_from_credentials_file(input_file, base_url_override: str | None = None) -> (OAuth1Session, OAuth1Client, str):
-        credentials = ETradeConnector._validate_connection_credentials(
+        credentials = ETradeConnectionCredentials.from_mapping(
             ETradeConnector._deserialize_connection_credentials(input_file)
         )
         base_url = (
             ETradeConnector._normalize_base_url(base_url_override, ETRADE_API_BASE_URL_ENV_VAR)
             if base_url_override
-            else credentials["base_url"]
+            else credentials.base_url
         )
         return ETradeConnector._build_connection_from_credentials(credentials, base_url)
 
     @staticmethod
-    def _build_connection_from_credentials(credentials: dict, base_url: str) -> (OAuth1Session, OAuth1Client, str):
+    def _build_connection_from_credentials(
+            credentials: ETradeConnectionCredentials | Mapping[str, object],
+            base_url: str) -> (OAuth1Session, OAuth1Client, str):
+        if not isinstance(credentials, ETradeConnectionCredentials):
+            credentials = ETradeConnectionCredentials.from_mapping(credentials)
+
         service = OAuth1Service(
             name="etrade",
-            consumer_key=credentials["consumer_key"],
-            consumer_secret=credentials["consumer_secret"],
+            consumer_key=credentials.consumer_key,
+            consumer_secret=credentials.consumer_secret,
             request_token_url="https://api.etrade.com/oauth/request_token",
             access_token_url="https://api.etrade.com/oauth/access_token",
             authorize_url="https://us.etrade.com/e/t/etws/authorize?key={}&token={}",
             base_url="https://api.etrade.com")
 
         session = OAuth1Session(
-            consumer_key=credentials["consumer_key"],
-            consumer_secret=credentials["consumer_secret"],
-            access_token=credentials["access_token"],
-            access_token_secret=credentials["access_token_secret"],
+            consumer_key=credentials.consumer_key,
+            consumer_secret=credentials.consumer_secret,
+            access_token=credentials.access_token,
+            access_token_secret=credentials.access_token_secret,
             service=service)
 
         async_session = OAuth1Client(
-            consumer_key=credentials["consumer_key"],
-            consumer_secret=credentials["consumer_secret"],
-            resource_owner_key=credentials["request_token"],
-            resource_owner_secret=credentials["request_token_secret"],
-            access_token_key=credentials["access_token"],
-            oauth_token=credentials["access_token"],
-            oauth_token_secret=credentials["access_token_secret"],
+            consumer_key=credentials.consumer_key,
+            consumer_secret=credentials.consumer_secret,
+            resource_owner_key=credentials.request_token,
+            resource_owner_secret=credentials.request_token_secret,
+            access_token_key=credentials.access_token,
+            oauth_token=credentials.access_token,
+            oauth_token_secret=credentials.access_token_secret,
             base_url=base_url,
             signature_method='HMAC-SHA1',
             signature_type="query")
@@ -382,52 +376,8 @@ class ETradeConnector(Connector):
 
     @staticmethod
     def _validate_connection_credentials(credentials: dict) -> dict:
-        if not isinstance(credentials, dict):
-            raise ValueError("E*Trade connection credentials must be a JSON object")
-
-        normalized_credentials = dict(credentials)
-        for field in REQUIRED_CREDENTIAL_FIELDS:
-            ETradeConnector._require_non_empty_string(normalized_credentials, field)
-
-        for field in OPTIONAL_CREDENTIAL_FIELDS:
-            if field not in normalized_credentials:
-                raise ValueError(f"E*Trade connection credentials must include {field}")
-            value = normalized_credentials[field]
-            if value is not None:
-                ETradeConnector._require_non_empty_string(normalized_credentials, field)
-
-        normalized_credentials["base_url"] = ETradeConnector._normalize_base_url(
-            normalized_credentials["base_url"],
-            "base_url",
-        )
-        return normalized_credentials
-
-    @staticmethod
-    def _require_non_empty_string(credentials: dict, field: str) -> None:
-        if field not in credentials:
-            raise ValueError(f"E*Trade connection credentials must include {field}")
-        value = credentials[field]
-        if not isinstance(value, str) or not value.strip():
-            raise ValueError(f"E*Trade connection credential {field} must be a non-empty string")
+        return ETradeConnectionCredentials.from_mapping(credentials).to_mapping()
 
     @staticmethod
     def _normalize_base_url(raw_base_url: str, source: str) -> str:
-        if not isinstance(raw_base_url, str) or not raw_base_url.strip():
-            raise ValueError(f"E*Trade {source} must be a non-empty URL")
-
-        base_url = raw_base_url.strip().rstrip("/")
-        parsed_url = urlparse(base_url)
-        if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
-            raise ValueError(f"E*Trade {source} must be an http(s) URL")
-
-        return base_url
-
-    @staticmethod
-    def _ensure_private_parent(output_file):
-        parent_dir = os.path.dirname(output_file)
-        os.makedirs(parent_dir, mode=0o700, exist_ok=True)
-        os.chmod(parent_dir, 0o700)
-
-    @staticmethod
-    def _chmod_private(output_file):
-        os.chmod(output_file, 0o600)
+        return normalize_etrade_base_url(raw_base_url, source)

--- a/tests/common/api/etrade/test_etrade_connector_config.py
+++ b/tests/common/api/etrade/test_etrade_connector_config.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import stat
@@ -12,6 +13,10 @@ from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import 
     ETRADE_API_BASE_URL_ENV_VAR,
     ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR,
     ETradeConnector,
+)
+from fianchetto_tradebot.server.common.brokerage.etrade.credentials import (
+    ETradeConnectionCredentials,
+    ETradeFileCredentialProvider,
 )
 
 
@@ -37,6 +42,101 @@ def test_connector_uses_sensible_fake_credentials_with_simulator_endpoint(tmp_pa
     assert connector.load_base_url() == "http://etrade-sim:8090"
     assert isinstance(connector.session, OAuth1Session)
     assert isinstance(connector.async_session, OAuth1Client)
+
+
+def test_connector_can_load_credentials_from_provider(tmp_path):
+    # Given
+    # A credential provider that does not depend on local files.
+    provider = _StaticCredentialProvider(
+        ETradeConnectionCredentials.from_mapping(
+            _credentials_dict(base_url="http://etrade-provider:8090/")
+        )
+    )
+
+    # When
+    # The connector is constructed with that provider.
+    connector = ETradeConnector(
+        config_file=str(tmp_path / "missing-config.ini"),
+        session_file=str(tmp_path / "missing-connection.json"),
+        async_session_file=str(tmp_path / "missing-connection.json"),
+        base_url_file=str(tmp_path / "missing-base-url.json"),
+        env={},
+        credential_provider=provider,
+    )
+
+    # Then
+    # It builds the normal OAuth-shaped sessions from the provider's credential document.
+    assert connector.base_url == "http://etrade-provider:8090"
+    assert connector.session.consumer_key == "simulator-consumer-key"
+    assert connector.async_session.oauth_token == "simulator-access-token"
+
+
+def test_connector_env_base_url_overrides_provider_endpoint(tmp_path):
+    # Given
+    # Provider credentials and a runtime endpoint override.
+    provider = _StaticCredentialProvider(
+        ETradeConnectionCredentials.from_mapping(
+            _credentials_dict(base_url="https://credential-cache.example.test")
+        )
+    )
+
+    # When
+    # The connector is created with both sources.
+    connector = ETradeConnector(
+        config_file=str(tmp_path / "missing-config.ini"),
+        session_file=str(tmp_path / "missing-connection.json"),
+        async_session_file=str(tmp_path / "missing-connection.json"),
+        base_url_file=str(tmp_path / "missing-base-url.json"),
+        env={ETRADE_API_BASE_URL_ENV_VAR: "http://etrade-sim:8090/"},
+        credential_provider=provider,
+    )
+
+    # Then
+    # Runtime configuration still wins over provider-supplied endpoint metadata.
+    assert connector.base_url == "http://etrade-sim:8090"
+    assert connector.async_session.base_url == "http://etrade-sim:8090"
+
+
+def test_file_credential_provider_round_trips_valid_credentials(tmp_path):
+    # Given
+    # A file-backed provider and structurally valid fake credentials.
+    credentials_file = tmp_path / "connection.json"
+    base_url_file = tmp_path / "base-url.json"
+    provider = ETradeFileCredentialProvider(
+        credentials_file=credentials_file,
+        base_url_file=base_url_file,
+        max_age=datetime.timedelta(hours=1),
+    )
+    credentials = ETradeConnectionCredentials.from_mapping(_credentials_dict())
+
+    # When
+    # The provider stores and reloads both the credential document and standalone base URL.
+    provider.store(credentials)
+    provider.store_base_url("http://etrade-sim:8090/")
+
+    # Then
+    # The loaded values are normalized and the local files are private.
+    assert provider.load() == credentials
+    assert provider.load_base_url() == "http://etrade-sim:8090"
+    assert stat.S_IMODE(credentials_file.stat().st_mode) == 0o600
+    assert stat.S_IMODE(base_url_file.stat().st_mode) == 0o600
+
+
+def test_connection_credentials_repr_redacts_secret_values():
+    # Given
+    # A validated credential document with OAuth-shaped fake values.
+    credentials = ETradeConnectionCredentials.from_mapping(_credentials_dict())
+
+    # When
+    # The value is represented in assertion output or debugging text.
+    representation = repr(credentials)
+
+    # Then
+    # The endpoint remains visible, but secret material is redacted.
+    assert "http://etrade-sim:8090" in representation
+    assert "simulator-consumer-secret" not in representation
+    assert "simulator-access-token" not in representation
+    assert "<redacted>" in representation
 
 
 def test_connector_accepts_serialized_session_credentials_without_request_tokens(tmp_path):
@@ -277,3 +377,20 @@ def _credentials_dict(**overrides) -> dict:
 def _make_old(path) -> None:
     old_timestamp = time.time() - (2 * 60 * 60)
     os.utime(path, (old_timestamp, old_timestamp))
+
+
+class _StaticCredentialProvider:
+    def __init__(self, credentials: ETradeConnectionCredentials):
+        self.credentials = credentials
+
+    def load(self) -> ETradeConnectionCredentials:
+        return self.credentials
+
+    def store(self, credentials: ETradeConnectionCredentials) -> None:
+        self.credentials = credentials
+
+    def load_base_url(self) -> None:
+        return None
+
+    def store_base_url(self, base_url: str) -> None:
+        return None


### PR DESCRIPTION
## Ticket

[FIA-171](https://linear.app/fianchetto-labs/issue/FIA-171/introduce-the-brokerage-credential-provider-interface)

## Summary

- Add an E*Trade credential document type with validation and redacted repr output.
- Add a credential provider protocol plus a file-backed provider that preserves today's local credential-cache behavior and private file permissions.
- Wire `ETradeConnector` to accept an injected credential provider while preserving existing constructor arguments and static compatibility helpers.
- Add focused tests for provider injection, endpoint precedence, file-backed round-trip behavior, and redaction.

## Verification

- `.venv/bin/python -m nox -s test -- tests/common/api/etrade/test_etrade_connector_config.py tests/common/api/orders/etrade/test_etrade_order_service.py tests/common/api/etrade/test_etrade_quotes_service.py` - 31 passed
- `.venv/bin/python -m nox -s unit` - 231 passed, 39 deselected
- `git diff --check`
- Sensitive-term scan reviewed on changed files: only fake test values and expected OAuth field handling are present.

## Scope

This creates the provider boundary and keeps current file-backed local behavior intact. Follow-up tickets still own moving all local E*Trade credential handling behind the provider, adding AWS Secrets Manager support, IAM/KMS policy, audit logging, live trading gates, client intake, rotation/revocation, and production readiness.
