### PR TITLE
FIA-172: Route local ETrade credentials through provider

### DIFF
--- a/src/fianchetto_tradebot/server/common/brokerage/etrade/credentials.py
+++ b/src/fianchetto_tradebot/server/common/brokerage/etrade/credentials.py
@@ -20,6 +20,15 @@ OPTIONAL_CREDENTIAL_FIELDS = (
     "request_token",
     "request_token_secret",
 )
+STATE_DIR_ENV_VAR = "FIANCHETTO_TRADEBOT_STATE_DIR"
+DEFAULT_STATE_DIR = Path.home() / ".fianchetto_tradebot"
+BROKERAGE_DIR = "etrade"
+CONNECTION_CREDENTIALS_FILE_NAME = "connection.json"
+BASE_URL_FILE_NAME = "base_url.json"
+REQUEST_TOKEN_FILE_NAME = "request_token.json"
+REQUEST_TOKEN_SECRET_FILE_NAME = "request_token_secret.json"
+OAUTH_TOKEN_FILE_NAME = "oauth_token.json"
+OAUTH_TOKEN_SECRET_FILE_NAME = "oauth_token_secret.json"
 
 
 @dataclass(frozen=True, repr=False)
@@ -95,15 +104,90 @@ class ETradeCredentialProvider(Protocol):
     def store_base_url(self, base_url: str) -> None:
         """Persist a standalone base URL fallback."""
 
+    def load_request_token(self) -> str:
+        """Return the locally cached OAuth request token."""
 
-class ETradeFileCredentialProvider:
+    def store_request_token(self, token: str) -> None:
+        """Persist the OAuth request token."""
+
+    def load_request_token_secret(self) -> str:
+        """Return the locally cached OAuth request token secret."""
+
+    def store_request_token_secret(self, token_secret: str) -> None:
+        """Persist the OAuth request token secret."""
+
+    def load_oauth_token(self) -> str:
+        """Return the locally cached OAuth token."""
+
+    def store_oauth_token(self, token: str) -> None:
+        """Persist the OAuth token."""
+
+    def load_oauth_token_secret(self) -> str:
+        """Return the locally cached OAuth token secret."""
+
+    def store_oauth_token_secret(self, token_secret: str) -> None:
+        """Persist the OAuth token secret."""
+
+
+@dataclass(frozen=True)
+class ETradeLocalCredentialFiles:
+    credentials_file: Path
+    base_url_file: Path
+    request_token_file: Path
+    request_token_secret_file: Path
+    oauth_token_file: Path
+    oauth_token_secret_file: Path
+
+
+def local_credential_files(
+        state_dir: str | os.PathLike[str] | None = None,
+        brokerage_dir: str = BROKERAGE_DIR) -> ETradeLocalCredentialFiles:
+    root = Path(state_dir or os.environ.get(STATE_DIR_ENV_VAR, DEFAULT_STATE_DIR))
+    brokerage_state_dir = root / brokerage_dir
+    return ETradeLocalCredentialFiles(
+        credentials_file=brokerage_state_dir / CONNECTION_CREDENTIALS_FILE_NAME,
+        base_url_file=brokerage_state_dir / BASE_URL_FILE_NAME,
+        request_token_file=brokerage_state_dir / REQUEST_TOKEN_FILE_NAME,
+        request_token_secret_file=brokerage_state_dir / REQUEST_TOKEN_SECRET_FILE_NAME,
+        oauth_token_file=brokerage_state_dir / OAUTH_TOKEN_FILE_NAME,
+        oauth_token_secret_file=brokerage_state_dir / OAUTH_TOKEN_SECRET_FILE_NAME,
+    )
+
+
+class ETradeLocalCredentialProvider:
     def __init__(
             self,
-            credentials_file: str | os.PathLike[str],
-            base_url_file: str | os.PathLike[str],
-            max_age: datetime.timedelta):
-        self.credentials_file = Path(credentials_file)
-        self.base_url_file = Path(base_url_file)
+            max_age: datetime.timedelta,
+            state_dir: str | os.PathLike[str] | None = None,
+            credentials_file: str | os.PathLike[str] | None = None,
+            base_url_file: str | os.PathLike[str] | None = None,
+            request_token_file: str | os.PathLike[str] | None = None,
+            request_token_secret_file: str | os.PathLike[str] | None = None,
+            oauth_token_file: str | os.PathLike[str] | None = None,
+            oauth_token_secret_file: str | os.PathLike[str] | None = None):
+        files = local_credential_files(state_dir=state_dir)
+        self.credentials_file = (
+            Path(credentials_file) if credentials_file is not None else files.credentials_file
+        )
+        self.base_url_file = (
+            Path(base_url_file) if base_url_file is not None else files.base_url_file
+        )
+        self.request_token_file = (
+            Path(request_token_file) if request_token_file is not None else files.request_token_file
+        )
+        self.request_token_secret_file = (
+            Path(request_token_secret_file)
+            if request_token_secret_file is not None
+            else files.request_token_secret_file
+        )
+        self.oauth_token_file = (
+            Path(oauth_token_file) if oauth_token_file is not None else files.oauth_token_file
+        )
+        self.oauth_token_secret_file = (
+            Path(oauth_token_secret_file)
+            if oauth_token_secret_file is not None
+            else files.oauth_token_secret_file
+        )
         self.max_age = max_age
 
     def load(self) -> ETradeConnectionCredentials | None:
@@ -121,6 +205,48 @@ class ETradeFileCredentialProvider:
 
     def store_base_url(self, base_url: str) -> None:
         _serialize_json_value(normalize_etrade_base_url(base_url, "base_url"), self.base_url_file)
+
+    def load_request_token(self) -> str:
+        return _deserialize_string_value(self.request_token_file, "request_token")
+
+    def store_request_token(self, token: str) -> None:
+        _serialize_json_value(token, self.request_token_file)
+
+    def load_request_token_secret(self) -> str:
+        return _deserialize_string_value(self.request_token_secret_file, "request_token_secret")
+
+    def store_request_token_secret(self, token_secret: str) -> None:
+        _serialize_json_value(token_secret, self.request_token_secret_file)
+
+    def load_oauth_token(self) -> str:
+        return _deserialize_string_value(self.oauth_token_file, "oauth_token")
+
+    def store_oauth_token(self, token: str) -> None:
+        _serialize_json_value(token, self.oauth_token_file)
+
+    def load_oauth_token_secret(self) -> str:
+        return _deserialize_string_value(self.oauth_token_secret_file, "oauth_token_secret")
+
+    def store_oauth_token_secret(self, token_secret: str) -> None:
+        _serialize_json_value(token_secret, self.oauth_token_secret_file)
+
+
+class ETradeFileCredentialProvider(ETradeLocalCredentialProvider):
+    def __init__(
+            self,
+            credentials_file: str | os.PathLike[str],
+            base_url_file: str | os.PathLike[str],
+            max_age: datetime.timedelta):
+        sidecar_dir = Path(credentials_file).parent
+        super().__init__(
+            credentials_file=credentials_file,
+            base_url_file=base_url_file,
+            request_token_file=sidecar_dir / REQUEST_TOKEN_FILE_NAME,
+            request_token_secret_file=sidecar_dir / REQUEST_TOKEN_SECRET_FILE_NAME,
+            oauth_token_file=sidecar_dir / OAUTH_TOKEN_FILE_NAME,
+            oauth_token_secret_file=sidecar_dir / OAUTH_TOKEN_SECRET_FILE_NAME,
+            max_age=max_age,
+        )
 
 
 def is_file_still_valid(input_file: str | os.PathLike[str], max_age: datetime.timedelta) -> bool:
@@ -185,6 +311,13 @@ def _serialize_json_value(value: object, output_file: str | os.PathLike[str]) ->
 def _deserialize_json_value(input_file: str | os.PathLike[str]) -> object:
     with open(Path(input_file)) as f:
         return json.load(f)["value"]
+
+
+def _deserialize_string_value(input_file: str | os.PathLike[str], field: str) -> str:
+    value = _deserialize_json_value(input_file)
+    if not isinstance(value, str):
+        raise ValueError(f"E*Trade credential {field} must be a string")
+    return value
 
 
 def _serialize_json_object(value: Mapping[str, object], output_file: str | os.PathLike[str]) -> None:

--- a/src/fianchetto_tradebot/server/common/brokerage/etrade/etrade_connector.py
+++ b/src/fianchetto_tradebot/server/common/brokerage/etrade/etrade_connector.py
@@ -11,10 +11,11 @@ from fianchetto_tradebot.server.common.brokerage.connector import Connector
 from fianchetto_tradebot.server.common.brokerage.etrade.credentials import (
     ETradeConnectionCredentials,
     ETradeCredentialProvider,
-    ETradeFileCredentialProvider,
+    ETradeLocalCredentialProvider,
     deserialize_connection_credentials,
     deserialize_json_value,
     is_file_still_valid,
+    local_credential_files,
     normalize_etrade_base_url,
     serialize_connection_credentials,
     serialize_json_value,
@@ -25,24 +26,21 @@ config = configparser.ConfigParser()
 DEFAULT_CONFIG_FILE = os.path.join(os.path.dirname(__file__), './config.ini')
 
 BROKERAGE_NAME = "ETRADE"
-BROKERAGE_DIR = "etrade"
-DEFAULT_STATE_DIR = os.path.join(os.path.expanduser("~"), ".fianchetto_tradebot")
-STATE_DIR = os.environ.get("FIANCHETTO_TRADEBOT_STATE_DIR", DEFAULT_STATE_DIR)
-BROKERAGE_STATE_DIR = os.path.join(STATE_DIR, BROKERAGE_DIR)
+DEFAULT_LOCAL_CREDENTIAL_FILES = local_credential_files()
 
 # TODO: Generalize this across all exchanges
-DEFAULT_CREDENTIALS_FILE = os.path.join(BROKERAGE_STATE_DIR, "connection.json")
+DEFAULT_CREDENTIALS_FILE = str(DEFAULT_LOCAL_CREDENTIAL_FILES.credentials_file)
 DEFAULT_SESSION_FILE = DEFAULT_CREDENTIALS_FILE
 DEFAULT_ASYNC_SESSION_FILE = DEFAULT_CREDENTIALS_FILE
-DEFAULT_ETRADE_BASE_URL_FILE = os.path.join(BROKERAGE_STATE_DIR, "base_url.json")
+DEFAULT_ETRADE_BASE_URL_FILE = str(DEFAULT_LOCAL_CREDENTIAL_FILES.base_url_file)
 ETRADE_API_BASE_URL_ENV_VAR = "TRADEBOT_ETRADE_API_BASE_URL"
 ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR = "TRADEBOT_ETRADE_CACHE_MAX_AGE_SECONDS"
 DEFAULT_CACHE_MAX_AGE_SECONDS = 60 * 60
 # For debugging
-REQUEST_TOKEN_FILE = os.path.join(BROKERAGE_STATE_DIR, "request_token.json")
-REQUEST_TOKEN_SECRET_FILE = os.path.join(BROKERAGE_STATE_DIR, "request_token_secret.json")
-OAUTH_TOKEN_FILE = os.path.join(BROKERAGE_STATE_DIR, "oauth_token.json")
-OAUTH_TOKEN_SECRET_FILE = os.path.join(BROKERAGE_STATE_DIR, "oauth_token_secret.json")
+REQUEST_TOKEN_FILE = str(DEFAULT_LOCAL_CREDENTIAL_FILES.request_token_file)
+REQUEST_TOKEN_SECRET_FILE = str(DEFAULT_LOCAL_CREDENTIAL_FILES.request_token_secret_file)
+OAUTH_TOKEN_FILE = str(DEFAULT_LOCAL_CREDENTIAL_FILES.oauth_token_file)
+OAUTH_TOKEN_SECRET_FILE = str(DEFAULT_LOCAL_CREDENTIAL_FILES.oauth_token_secret_file)
 
 
 class ETradeConnector(Connector):
@@ -111,10 +109,10 @@ class ETradeConnector(Connector):
             self.credential_provider = self._default_credential_provider()
         return self.credential_provider
 
-    def _default_credential_provider(self) -> ETradeFileCredentialProvider:
-        return ETradeFileCredentialProvider(
-            credentials_file=self.credentials_file,
-            base_url_file=self.base_url_file,
+    def _default_credential_provider(self) -> ETradeLocalCredentialProvider:
+        return ETradeLocalCredentialProvider(
+            credentials_file=getattr(self, "credentials_file", DEFAULT_CREDENTIALS_FILE),
+            base_url_file=getattr(self, "base_url_file", DEFAULT_ETRADE_BASE_URL_FILE),
             max_age=self._cache_max_age(),
         )
 
@@ -125,7 +123,8 @@ class ETradeConnector(Connector):
         return ETradeConnector._normalize_base_url(raw_base_url, ETRADE_API_BASE_URL_ENV_VAR)
 
     def _cache_max_age(self) -> datetime.timedelta:
-        raw_max_age = self.env.get(ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR)
+        env = getattr(self, "env", os.environ)
+        raw_max_age = env.get(ETRADE_CACHE_MAX_AGE_SECONDS_ENV_VAR)
         if raw_max_age is None:
             return datetime.timedelta(seconds=DEFAULT_CACHE_MAX_AGE_SECONDS)
         try:
@@ -246,33 +245,24 @@ class ETradeConnector(Connector):
         })
 
     def serialize_request_token(self, token: str):
-        ETradeConnector._serialize_json_value(token, REQUEST_TOKEN_FILE)
+        self._credential_provider().store_request_token(token)
 
     def serialize_request_token_secret(self, token_secret: str):
-        ETradeConnector._serialize_json_value(token_secret, REQUEST_TOKEN_SECRET_FILE)
+        self._credential_provider().store_request_token_secret(token_secret)
 
     def serialize_oauth_token(self, token: str):
-        ETradeConnector._serialize_json_value(token, OAUTH_TOKEN_FILE)
+        self._credential_provider().store_oauth_token(token)
 
     def serialize_oauth_token_secret(self, token_secret: str):
-        ETradeConnector._serialize_json_value(token_secret, OAUTH_TOKEN_SECRET_FILE)
+        self._credential_provider().store_oauth_token_secret(token_secret)
 
     def serialize_base_url(self, base_url: str):
         base_url = ETradeConnector._normalize_base_url(base_url, "base_url")
-        if hasattr(self, "credential_provider"):
-            self.credential_provider.store_base_url(base_url)
-            return
-        ETradeConnector._serialize_json_value(base_url, self.base_url_file)
+        self._credential_provider().store_base_url(base_url)
 
     def _store_connection_credentials(self, credentials: Mapping[str, object]) -> None:
         credential_document = ETradeConnectionCredentials.from_mapping(credentials)
-        if hasattr(self, "credential_provider"):
-            self.credential_provider.store(credential_document)
-            return
-        ETradeConnector._serialize_connection_credentials(
-            credential_document.to_mapping(),
-            self.credentials_file,
-        )
+        self._credential_provider().store(credential_document)
 
     @staticmethod
     def deserialize_session(input=DEFAULT_SESSION_FILE) -> OAuth1Session:
@@ -284,19 +274,31 @@ class ETradeConnector(Connector):
 
     @staticmethod
     def deserialize_request_token(input=REQUEST_TOKEN_FILE) -> str:
-        return ETradeConnector._deserialize_json_value(input)
+        return ETradeLocalCredentialProvider(
+            request_token_file=input,
+            max_age=datetime.timedelta.max,
+        ).load_request_token()
 
     @staticmethod
     def deserialize_request_token_secret(input=REQUEST_TOKEN_SECRET_FILE) -> str:
-        return ETradeConnector._deserialize_json_value(input)
+        return ETradeLocalCredentialProvider(
+            request_token_secret_file=input,
+            max_age=datetime.timedelta.max,
+        ).load_request_token_secret()
 
     @staticmethod
     def deserialize_oauth_token(input=OAUTH_TOKEN_FILE) -> str:
-        return ETradeConnector._deserialize_json_value(input)
+        return ETradeLocalCredentialProvider(
+            oauth_token_file=input,
+            max_age=datetime.timedelta.max,
+        ).load_oauth_token()
 
     @staticmethod
     def deserialize_oauth_token_secret(input=OAUTH_TOKEN_SECRET_FILE) -> str:
-        return ETradeConnector._deserialize_json_value(input)
+        return ETradeLocalCredentialProvider(
+            oauth_token_secret_file=input,
+            max_age=datetime.timedelta.max,
+        ).load_oauth_token_secret()
 
     @staticmethod
     def deserialize_base_url(input=DEFAULT_ETRADE_BASE_URL_FILE) -> str:

--- a/tests/common/api/etrade/test_etrade_connector_config.py
+++ b/tests/common/api/etrade/test_etrade_connector_config.py
@@ -17,6 +17,8 @@ from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import 
 from fianchetto_tradebot.server.common.brokerage.etrade.credentials import (
     ETradeConnectionCredentials,
     ETradeFileCredentialProvider,
+    ETradeLocalCredentialProvider,
+    local_credential_files,
 )
 
 
@@ -113,13 +115,95 @@ def test_file_credential_provider_round_trips_valid_credentials(tmp_path):
     # The provider stores and reloads both the credential document and standalone base URL.
     provider.store(credentials)
     provider.store_base_url("http://etrade-sim:8090/")
+    provider.store_request_token("simulator-request-token")
 
     # Then
     # The loaded values are normalized and the local files are private.
     assert provider.load() == credentials
     assert provider.load_base_url() == "http://etrade-sim:8090"
+    assert provider.load_request_token() == "simulator-request-token"
+    assert provider.request_token_file.parent == credentials_file.parent
     assert stat.S_IMODE(credentials_file.stat().st_mode) == 0o600
     assert stat.S_IMODE(base_url_file.stat().st_mode) == 0o600
+
+
+def test_local_credential_provider_owns_state_dir_layout(tmp_path):
+    # Given
+    # A local state directory that should contain all E*Trade credential artifacts.
+    provider = ETradeLocalCredentialProvider(
+        state_dir=tmp_path,
+        max_age=datetime.timedelta(hours=1),
+    )
+    files = local_credential_files(state_dir=tmp_path)
+    credentials = ETradeConnectionCredentials.from_mapping(_credentials_dict())
+
+    # When
+    # The provider persists connection, base URL, and legacy token sidecar values.
+    provider.store(credentials)
+    provider.store_base_url("http://etrade-sim:8090/")
+    provider.store_request_token("simulator-request-token")
+    provider.store_request_token_secret("simulator-request-token-secret")
+    provider.store_oauth_token("simulator-oauth-token")
+    provider.store_oauth_token_secret("simulator-oauth-token-secret")
+
+    # Then
+    # The files live under the expected local brokerage state directory with private permissions.
+    assert provider.credentials_file == files.credentials_file
+    assert provider.base_url_file == files.base_url_file
+    assert provider.load() == credentials
+    assert provider.load_base_url() == "http://etrade-sim:8090"
+    assert provider.load_request_token() == "simulator-request-token"
+    assert provider.load_request_token_secret() == "simulator-request-token-secret"
+    assert provider.load_oauth_token() == "simulator-oauth-token"
+    assert provider.load_oauth_token_secret() == "simulator-oauth-token-secret"
+    assert stat.S_IMODE(files.credentials_file.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(files.request_token_file.stat().st_mode) == 0o600
+
+
+def test_connector_serializes_token_sidecars_through_provider(tmp_path):
+    # Given
+    # A connector with an injected provider rather than the default local files.
+    provider = _StaticCredentialProvider(
+        ETradeConnectionCredentials.from_mapping(_credentials_dict())
+    )
+    connector = ETradeConnector(
+        config_file=str(tmp_path / "missing-config.ini"),
+        session_file=str(tmp_path / "missing-connection.json"),
+        async_session_file=str(tmp_path / "missing-connection.json"),
+        base_url_file=str(tmp_path / "missing-base-url.json"),
+        env={},
+        credential_provider=provider,
+    )
+
+    # When
+    # Legacy token sidecar methods are called.
+    connector.serialize_request_token("request-token")
+    connector.serialize_request_token_secret("request-token-secret")
+    connector.serialize_oauth_token("oauth-token")
+    connector.serialize_oauth_token_secret("oauth-token-secret")
+
+    # Then
+    # The provider receives those values instead of the connector writing direct local files.
+    assert provider.request_token == "request-token"
+    assert provider.request_token_secret == "request-token-secret"
+    assert provider.oauth_token == "oauth-token"
+    assert provider.oauth_token_secret == "oauth-token-secret"
+
+
+def test_local_credential_provider_rejects_non_string_token_sidecar(tmp_path):
+    # Given
+    # A malformed local token sidecar file.
+    provider = ETradeLocalCredentialProvider(
+        state_dir=tmp_path,
+        max_age=datetime.timedelta(hours=1),
+    )
+    provider.request_token_file.parent.mkdir(parents=True)
+    provider.request_token_file.write_text(json.dumps({"value": {"not": "a string"}}))
+
+    # When / Then
+    # Loading the sidecar fails without printing the malformed value.
+    with pytest.raises(ValueError, match="request_token"):
+        provider.load_request_token()
 
 
 def test_connection_credentials_repr_redacts_secret_values():
@@ -382,6 +466,10 @@ def _make_old(path) -> None:
 class _StaticCredentialProvider:
     def __init__(self, credentials: ETradeConnectionCredentials):
         self.credentials = credentials
+        self.request_token = None
+        self.request_token_secret = None
+        self.oauth_token = None
+        self.oauth_token_secret = None
 
     def load(self) -> ETradeConnectionCredentials:
         return self.credentials
@@ -394,3 +482,27 @@ class _StaticCredentialProvider:
 
     def store_base_url(self, base_url: str) -> None:
         return None
+
+    def load_request_token(self) -> str | None:
+        return self.request_token
+
+    def store_request_token(self, token: str) -> None:
+        self.request_token = token
+
+    def load_request_token_secret(self) -> str | None:
+        return self.request_token_secret
+
+    def store_request_token_secret(self, token_secret: str) -> None:
+        self.request_token_secret = token_secret
+
+    def load_oauth_token(self) -> str | None:
+        return self.oauth_token
+
+    def store_oauth_token(self, token: str) -> None:
+        self.oauth_token = token
+
+    def load_oauth_token_secret(self) -> str | None:
+        return self.oauth_token_secret
+
+    def store_oauth_token_secret(self, token_secret: str) -> None:
+        self.oauth_token_secret = token_secret


### PR DESCRIPTION
## Ticket

[FIA-172](https://linear.app/fianchetto-labs/issue/FIA-172/move-local-etrade-credentials-behind-an-explicit-local-provider)

## Summary

- Add an explicit `ETradeLocalCredentialProvider` that owns the local E*Trade state directory layout.
- Route connection credentials, base URL fallback, and legacy OAuth token sidecars through the provider instead of direct connector file writes.
- Keep the narrower `ETradeFileCredentialProvider` as a compatibility wrapper with sidecars colocated beside the supplied credential file.
- Add tests for local state layout, provider-routed token sidecar writes, sidecar permissions, and malformed sidecar validation.

## Verification

- `.venv/bin/python -m nox -s test -- tests/common/api/etrade/test_etrade_connector_config.py tests/common/api/orders/etrade/test_etrade_order_service.py tests/common/api/etrade/test_etrade_quotes_service.py` - 34 passed
- `.venv/bin/python -m nox -s unit` - 234 passed, 39 deselected
- `git diff --check`
- Sensitive-term scan reviewed on changed files: only fake simulator values and expected OAuth/credential field handling are present.

## Scope

This keeps local development behavior file-backed and explicit. AWS Secrets Manager, KMS/IAM, audit logging, live trading gates, client intake, rotation/revocation, and production readiness remain follow-up tickets.
