### PR TITLE
FIA-173: Add ETrade AWS credential provider

### DIFF
--- a/docs/credential-trust-model.md
+++ b/docs/credential-trust-model.md
@@ -103,6 +103,32 @@ This mode can support a careful live demo, but it is still weaker than
 third-party custody because the system operator owns both the infrastructure and
 the brokerage account.
 
+### AWS Secrets Manager Provider
+
+The E*Trade AWS Secrets Manager provider reads and writes the same validated
+credential document as local development, but stores it as one JSON
+`SecretString` in an existing AWS Secrets Manager secret. The provider does not
+create secrets; secret creation, KMS key choice, IAM policy, and rotation policy
+belong to the infrastructure custody tickets.
+
+Expected secret document shape:
+
+```json
+{
+  "consumer_key": "example-consumer-key",
+  "consumer_secret": "example-consumer-secret",
+  "access_token": "example-access-token",
+  "access_token_secret": "example-access-token-secret",
+  "request_token": "example-request-token",
+  "request_token_secret": "example-request-token-secret",
+  "base_url": "https://api.etrade.com"
+}
+```
+
+The credential provider treats `ResourceNotFoundException` as absent credential
+state. Other AWS, JSON, and validation failures are surfaced without printing
+secret values.
+
 ## Third-Party Client Mode
 
 Third-party client mode is the long-term trust target. A client grants TradeBot

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -89,6 +89,13 @@ Important runtime configuration:
 | `TRADEBOT_ORDERS_SERVICE_URL` | Tells MOEX where the orders service lives in HTTP mode. |
 | `TRADEBOT_QUOTES_SERVICE_URL` | Tells MOEX where the quotes service lives in HTTP mode. |
 
+Hosted AWS deployments can use
+`ETradeAwsSecretsManagerCredentialProvider` to load a validated E*Trade
+credential document from an existing AWS Secrets Manager secret. The service
+role should be limited to the intended secret and the required read/write
+operations; KMS/IAM policy details are tracked separately from local Docker
+configuration.
+
 `TRADEBOT_MOEX_SERVICE_ADAPTER_MODE` defaults to `local` for simple developer
 startup. When it is set to `http`, both `TRADEBOT_ORDERS_SERVICE_URL` and
 `TRADEBOT_QUOTES_SERVICE_URL` must be set explicitly so containerized startup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "anyio>=4.9,<5.0",
     "attrs>=25.3,<26.0",
     "blinker>=1.9,<2.0",
+    "boto3>=1.35,<2.0",
     "certifi>=2025.1,<2026.0",
     "charset-normalizer>=3.4,<4.0",
     "click>=8.1,<9.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ annotated-types>=0.7,<1.0
 anyio>=4.9,<5.0
 attrs>=25.3,<26.0
 blinker>=1.9,<2.0
+boto3>=1.35,<2.0
 certifi>=2025.1,<2026.0
 charset-normalizer>=3.4,<4.0
 click>=8.1,<9.0

--- a/src/fianchetto_tradebot/server/common/brokerage/etrade/aws_credentials.py
+++ b/src/fianchetto_tradebot/server/common/brokerage/etrade/aws_credentials.py
@@ -1,0 +1,154 @@
+import json
+from json import JSONDecodeError
+from typing import Mapping, Protocol
+
+from fianchetto_tradebot.server.common.brokerage.etrade.credentials import (
+    ETradeConnectionCredentials,
+    normalize_etrade_base_url,
+)
+
+
+class SecretsManagerClient(Protocol):
+    def get_secret_value(self, *, SecretId: str) -> Mapping[str, object]:
+        """Return a Secrets Manager secret value response."""
+
+    def put_secret_value(self, *, SecretId: str, SecretString: str) -> object:
+        """Store a new Secrets Manager secret string version."""
+
+
+class ETradeAwsSecretsManagerCredentialProvider:
+    """Stores one E*Trade credential document in an existing AWS secret."""
+
+    def __init__(
+            self,
+            secret_id: str,
+            region_name: str | None = None,
+            client: SecretsManagerClient | None = None,
+            boto3_session: object | None = None):
+        if not isinstance(secret_id, str) or not secret_id.strip():
+            raise ValueError("E*Trade AWS Secrets Manager secret_id must be a non-empty string")
+        self.secret_id = secret_id.strip()
+        self._client = client or _build_secrets_manager_client(
+            region_name=region_name,
+            boto3_session=boto3_session,
+        )
+
+    def load(self) -> ETradeConnectionCredentials | None:
+        secret = self._load_secret_document()
+        if secret is None:
+            return None
+        return ETradeConnectionCredentials.from_mapping(secret)
+
+    def store(self, credentials: ETradeConnectionCredentials) -> None:
+        self._store_secret_document(credentials.to_mapping())
+
+    def load_base_url(self) -> str | None:
+        return self._load_string_field("base_url", required=False)
+
+    def store_base_url(self, base_url: str) -> None:
+        self._store_secret_field("base_url", normalize_etrade_base_url(base_url, "base_url"))
+
+    def load_request_token(self) -> str:
+        return self._load_string_field("request_token")
+
+    def store_request_token(self, token: str) -> None:
+        self._store_secret_field("request_token", token)
+
+    def load_request_token_secret(self) -> str:
+        return self._load_string_field("request_token_secret")
+
+    def store_request_token_secret(self, token_secret: str) -> None:
+        self._store_secret_field("request_token_secret", token_secret)
+
+    def load_oauth_token(self) -> str:
+        return self._load_string_field("oauth_token")
+
+    def store_oauth_token(self, token: str) -> None:
+        self._store_secret_field("oauth_token", token)
+
+    def load_oauth_token_secret(self) -> str:
+        return self._load_string_field("oauth_token_secret")
+
+    def store_oauth_token_secret(self, token_secret: str) -> None:
+        self._store_secret_field("oauth_token_secret", token_secret)
+
+    def _load_string_field(self, field: str, required: bool = True) -> str | None:
+        secret = self._load_secret_document()
+        if secret is None:
+            if required:
+                raise ValueError(f"E*Trade AWS credential secret does not contain {field}")
+            return None
+
+        value = secret.get(field)
+        if value is None and not required:
+            return None
+        if not isinstance(value, str):
+            raise ValueError(f"E*Trade AWS credential secret field {field} must be a string")
+        return value
+
+    def _store_secret_field(self, field: str, value: str) -> None:
+        secret = self._load_secret_document()
+        if secret is None:
+            raise ValueError("E*Trade AWS credential secret must exist before fields can be updated")
+        secret[field] = value
+        self._store_secret_document(secret)
+
+    def _load_secret_document(self) -> dict[str, object] | None:
+        response = self._get_secret_value()
+        if response is None:
+            return None
+
+        if "SecretString" not in response:
+            raise ValueError("E*Trade AWS credential secret must contain SecretString")
+
+        secret_string = response["SecretString"]
+        if not isinstance(secret_string, str):
+            raise ValueError("E*Trade AWS credential SecretString must be a string")
+
+        try:
+            secret = json.loads(secret_string)
+        except JSONDecodeError as exc:
+            raise ValueError("E*Trade AWS credential SecretString must be valid JSON") from exc
+
+        if not isinstance(secret, dict):
+            raise ValueError("E*Trade AWS credential SecretString must contain a JSON object")
+
+        return secret
+
+    def _get_secret_value(self) -> Mapping[str, object] | None:
+        try:
+            return self._client.get_secret_value(SecretId=self.secret_id)
+        except Exception as exc:
+            if _is_resource_not_found_error(exc):
+                return None
+            raise
+
+    def _store_secret_document(self, secret: Mapping[str, object]) -> None:
+        self._client.put_secret_value(
+            SecretId=self.secret_id,
+            SecretString=json.dumps(secret),
+        )
+
+
+def _build_secrets_manager_client(
+        region_name: str | None,
+        boto3_session: object | None) -> SecretsManagerClient:
+    if boto3_session is None:
+        import boto3
+
+        boto3_session = boto3.session.Session()
+
+    client_args = {"service_name": "secretsmanager"}
+    if region_name:
+        client_args["region_name"] = region_name
+    return boto3_session.client(**client_args)
+
+
+def _is_resource_not_found_error(exc: Exception) -> bool:
+    response = getattr(exc, "response", None)
+    if not isinstance(response, Mapping):
+        return False
+    error = response.get("Error")
+    if not isinstance(error, Mapping):
+        return False
+    return error.get("Code") == "ResourceNotFoundException"

--- a/tests/common/api/etrade/test_etrade_aws_secrets_manager_credentials.py
+++ b/tests/common/api/etrade/test_etrade_aws_secrets_manager_credentials.py
@@ -1,0 +1,209 @@
+import json
+
+import pytest
+
+from fianchetto_tradebot.server.common.brokerage.etrade.aws_credentials import (
+    ETradeAwsSecretsManagerCredentialProvider,
+)
+from fianchetto_tradebot.server.common.brokerage.etrade.credentials import (
+    ETradeConnectionCredentials,
+)
+from tests.fixtures.aws_secrets_manager import FakeSecretsManagerClient
+
+
+SECRET_ID = "tradebot/etrade/live/operator"
+
+
+def test_aws_provider_loads_connection_credentials_from_secret_string():
+    # Given
+    # An existing Secrets Manager secret containing the E*Trade credential document.
+    client = FakeSecretsManagerClient({
+        SECRET_ID: json.dumps(_credentials_dict(base_url="https://api.etrade.com/")),
+    })
+    provider = ETradeAwsSecretsManagerCredentialProvider(secret_id=SECRET_ID, client=client)
+
+    # When
+    # The provider loads the credential document through the AWS-shaped client boundary.
+    credentials = provider.load()
+
+    # Then
+    # The same domain validation and normalization used by local credentials still applies.
+    assert credentials == ETradeConnectionCredentials.from_mapping(
+        _credentials_dict(base_url="https://api.etrade.com")
+    )
+    assert client.get_secret_value_calls == [SECRET_ID]
+
+
+def test_aws_provider_stores_connection_credentials_as_secret_string():
+    # Given
+    # A pre-created Secrets Manager secret and validated E*Trade credentials.
+    client = FakeSecretsManagerClient({SECRET_ID: json.dumps(_credentials_dict())})
+    provider = ETradeAwsSecretsManagerCredentialProvider(secret_id=SECRET_ID, client=client)
+    credentials = ETradeConnectionCredentials.from_mapping(
+        _credentials_dict(base_url="http://etrade-simulator:8090/")
+    )
+
+    # When
+    # The full connection credential document is stored.
+    provider.store(credentials)
+
+    # Then
+    # The AWS boundary receives one SecretString JSON document, not local sidecar files.
+    assert len(client.put_secret_value_calls) == 1
+    assert client.put_secret_value_calls[0][0] == SECRET_ID
+    assert client.secret_document(SECRET_ID) == credentials.to_mapping()
+
+
+def test_aws_provider_updates_base_url_inside_existing_secret_document():
+    # Given
+    # A full existing credential document in Secrets Manager.
+    client = FakeSecretsManagerClient({SECRET_ID: json.dumps(_credentials_dict())})
+    provider = ETradeAwsSecretsManagerCredentialProvider(secret_id=SECRET_ID, client=client)
+
+    # When
+    # The provider updates the runtime endpoint metadata.
+    provider.store_base_url("http://etrade-simulator:8090/")
+
+    # Then
+    # The base URL is normalized and the other secret fields are preserved.
+    assert provider.load_base_url() == "http://etrade-simulator:8090"
+    document = client.secret_document(SECRET_ID)
+    assert document["base_url"] == "http://etrade-simulator:8090"
+    assert document["consumer_secret"] == "simulator-consumer-secret"
+
+
+def test_aws_provider_updates_legacy_token_fields_inside_existing_secret_document():
+    # Given
+    # A full existing credential document in Secrets Manager.
+    client = FakeSecretsManagerClient({SECRET_ID: json.dumps(_credentials_dict())})
+    provider = ETradeAwsSecretsManagerCredentialProvider(secret_id=SECRET_ID, client=client)
+
+    # When
+    # Legacy OAuth token fields are written through the provider.
+    provider.store_request_token("updated-request-token")
+    provider.store_request_token_secret("updated-request-token-secret")
+    provider.store_oauth_token("updated-oauth-token")
+    provider.store_oauth_token_secret("updated-oauth-token-secret")
+
+    # Then
+    # They are persisted in the same AWS secret document and round-trip as strings.
+    assert provider.load_request_token() == "updated-request-token"
+    assert provider.load_request_token_secret() == "updated-request-token-secret"
+    assert provider.load_oauth_token() == "updated-oauth-token"
+    assert provider.load_oauth_token_secret() == "updated-oauth-token-secret"
+
+
+def test_aws_provider_returns_none_when_secret_does_not_exist():
+    # Given
+    # A provider pointing at a missing AWS secret.
+    provider = ETradeAwsSecretsManagerCredentialProvider(
+        secret_id=SECRET_ID,
+        client=FakeSecretsManagerClient(),
+    )
+
+    # When / Then
+    # Missing cloud state is treated like an absent local credential cache.
+    assert provider.load() is None
+    assert provider.load_base_url() is None
+
+
+def test_aws_provider_rejects_malformed_secret_string_without_exposing_value():
+    # Given
+    # A secret whose payload is not valid JSON.
+    client = FakeSecretsManagerClient({SECRET_ID: "not-json-with-simulator-consumer-secret"})
+    provider = ETradeAwsSecretsManagerCredentialProvider(secret_id=SECRET_ID, client=client)
+
+    # When / Then
+    # The failure explains the shape problem without printing the secret payload.
+    with pytest.raises(ValueError) as exc_info:
+        provider.load()
+    assert "valid JSON" in str(exc_info.value)
+    assert "simulator-consumer-secret" not in str(exc_info.value)
+
+
+def test_aws_provider_rejects_secret_without_secret_string():
+    # Given
+    # An AWS response containing binary secret material instead of a JSON string.
+    class BinarySecretClient(FakeSecretsManagerClient):
+        def get_secret_value(self, *, SecretId: str) -> dict[str, object]:
+            return {"SecretBinary": b"opaque"}
+
+    provider = ETradeAwsSecretsManagerCredentialProvider(
+        secret_id=SECRET_ID,
+        client=BinarySecretClient(),
+    )
+
+    # When / Then
+    # The provider fails closed instead of trying to parse an unsupported secret shape.
+    with pytest.raises(ValueError, match="SecretString"):
+        provider.load()
+
+
+def test_aws_provider_rejects_blank_secret_id():
+    # Given / When / Then
+    # The provider requires a stable configured AWS secret identifier.
+    with pytest.raises(ValueError, match="secret_id"):
+        ETradeAwsSecretsManagerCredentialProvider(secret_id=" ", client=FakeSecretsManagerClient())
+
+
+def test_aws_provider_requires_existing_secret_before_field_updates():
+    # Given
+    # A provider pointing at a missing AWS secret.
+    provider = ETradeAwsSecretsManagerCredentialProvider(
+        secret_id=SECRET_ID,
+        client=FakeSecretsManagerClient(),
+    )
+
+    # When / Then
+    # Incremental updates do not silently create partial credential documents.
+    with pytest.raises(ValueError, match="must exist"):
+        provider.store_base_url("http://etrade-simulator:8090")
+
+
+def test_aws_provider_builds_secrets_manager_client_from_boto3_session():
+    # Given
+    # A boto3-shaped session object and a configured AWS region.
+    class FakeBoto3Session:
+        def __init__(self):
+            self.client_args = None
+            self.client_kwargs = None
+
+        def client(self, *args, **kwargs) -> FakeSecretsManagerClient:
+            self.client_args = args
+            self.client_kwargs = kwargs
+            return FakeSecretsManagerClient({
+                SECRET_ID: json.dumps(_credentials_dict()),
+            })
+
+    boto3_session = FakeBoto3Session()
+
+    # When
+    # The provider owns client construction.
+    provider = ETradeAwsSecretsManagerCredentialProvider(
+        secret_id=SECRET_ID,
+        region_name="us-east-1",
+        boto3_session=boto3_session,
+    )
+
+    # Then
+    # It requests the AWS Secrets Manager client for the configured region.
+    assert provider.load() == ETradeConnectionCredentials.from_mapping(_credentials_dict())
+    assert boto3_session.client_args == ()
+    assert boto3_session.client_kwargs == {
+        "service_name": "secretsmanager",
+        "region_name": "us-east-1",
+    }
+
+
+def _credentials_dict(**overrides) -> dict[str, object]:
+    credentials = {
+        "consumer_key": "simulator-consumer-key",
+        "consumer_secret": "simulator-consumer-secret",
+        "access_token": "simulator-access-token",
+        "access_token_secret": "simulator-access-token-secret",
+        "request_token": "simulator-request-token",
+        "request_token_secret": "simulator-request-token-secret",
+        "base_url": "http://etrade-sim:8090",
+    }
+    credentials.update(overrides)
+    return credentials

--- a/tests/fixtures/aws_secrets_manager.py
+++ b/tests/fixtures/aws_secrets_manager.py
@@ -1,0 +1,30 @@
+import json
+
+
+class FakeResourceNotFound(Exception):
+    def __init__(self, secret_id: str):
+        super().__init__(f"Secret does not exist: {secret_id}")
+        self.response = {"Error": {"Code": "ResourceNotFoundException"}}
+
+
+class FakeSecretsManagerClient:
+    def __init__(self, secrets: dict[str, str] | None = None):
+        self.secrets = secrets or {}
+        self.get_secret_value_calls: list[str] = []
+        self.put_secret_value_calls: list[tuple[str, str]] = []
+
+    def get_secret_value(self, *, SecretId: str) -> dict[str, object]:
+        self.get_secret_value_calls.append(SecretId)
+        if SecretId not in self.secrets:
+            raise FakeResourceNotFound(SecretId)
+        return {"SecretString": self.secrets[SecretId]}
+
+    def put_secret_value(self, *, SecretId: str, SecretString: str) -> dict[str, object]:
+        self.put_secret_value_calls.append((SecretId, SecretString))
+        if SecretId not in self.secrets:
+            raise FakeResourceNotFound(SecretId)
+        self.secrets[SecretId] = SecretString
+        return {"VersionId": "fake-version-id"}
+
+    def secret_document(self, secret_id: str) -> dict[str, object]:
+        return json.loads(self.secrets[secret_id])


### PR DESCRIPTION
## Summary
- Add `ETradeAwsSecretsManagerCredentialProvider` for storing the validated E*Trade credential document in an existing AWS Secrets Manager `SecretString`.
- Add a strict fake Secrets Manager client and provider tests for load/store, field updates, missing secrets, malformed payloads, binary payloads, and boto3 session client construction.
- Document the hosted AWS credential-provider convention and add `boto3` to runtime dependencies.

## Ticket
- [FIA-173: Add an AWS Secrets Manager credential provider](https://linear.app/fianchetto-labs/issue/FIA-173/add-an-aws-secrets-manager-credential-provider)

## Verification
- `python -m nox -s test -- tests/common/api/etrade/test_etrade_aws_secrets_manager_credentials.py tests/common/api/etrade/test_etrade_connector_config.py` - 31 passed
- `python -m nox -s unit` - 244 passed, 39 deselected
- `git diff --check` - passed

## Notes
- The provider assumes the AWS secret already exists. Secret creation, KMS key policy, IAM permissions, and rotation stay in the follow-up infrastructure custody tickets.
- The provider treats AWS `ResourceNotFoundException` as absent credential state; other AWS, JSON, and validation errors surface without printing secret values.
