### PR TITLE
FIA-174: Add AWS credential custody policy templates

### DIFF
--- a/deploy/aws/credential-custody/README.md
+++ b/deploy/aws/credential-custody/README.md
@@ -1,0 +1,75 @@
+# AWS Credential Custody Policy Templates
+
+These templates define the first hosted AWS boundary for E*Trade credentials:
+the TradeBot runtime can read and update one existing Secrets Manager secret,
+and KMS key use is constrained to Secrets Manager.
+
+They are policy templates, not a complete infrastructure stack. Replace each
+`${...}` placeholder before applying them.
+
+## Runtime Role Policy
+
+Use `etrade-runtime-secret-policy.json` as an identity policy attached to the
+service role that runs TradeBot.
+
+The runtime role can:
+
+- Read secret metadata with `secretsmanager:DescribeSecret`.
+- Read the current credential document with `secretsmanager:GetSecretValue`.
+- Write a new credential version with `secretsmanager:PutSecretValue`.
+- Use the credential KMS key only through Secrets Manager in the configured
+  region and only for the configured secret ARN.
+
+The runtime role cannot:
+
+- Create or delete secrets.
+- List unrelated secrets.
+- Change secret resource policies.
+- Use the KMS key directly outside Secrets Manager.
+
+## KMS Key Policy
+
+Use `etrade-credential-kms-key-policy.json` as the customer-managed KMS key
+policy for the credential key.
+
+The key policy separates three actors:
+
+- The AWS account root principal keeps IAM policy delegation enabled.
+- The credential admin role can administer the key but cannot decrypt
+  credential data through this template.
+- The TradeBot runtime role can encrypt/decrypt only through Secrets Manager
+  for the configured region and credential secret ARN.
+
+## Placeholders
+
+| Placeholder | Meaning |
+| --- | --- |
+| `${AWS_ACCOUNT_ID}` | AWS account id that owns the secret, key, and roles. |
+| `${AWS_REGION}` | AWS region for the secret and KMS key. |
+| `${TRADEBOT_ETRADE_SECRET_NAME}` | Base Secrets Manager secret name, without the AWS random suffix. |
+| `${TRADEBOT_CREDENTIAL_KMS_KEY_ID}` | Customer-managed KMS key id used by the secret. |
+| `${TRADEBOT_RUNTIME_ROLE_ARN}` | IAM role assumed by the TradeBot service process. |
+| `${TRADEBOT_CREDENTIAL_ADMIN_ROLE_ARN}` | IAM role allowed to administer the credential KMS key. |
+
+Secrets Manager secret ARNs include an AWS-generated suffix, so the runtime
+policy uses:
+
+```text
+arn:aws:secretsmanager:${AWS_REGION}:${AWS_ACCOUNT_ID}:secret:${TRADEBOT_ETRADE_SECRET_NAME}-*
+```
+
+If you know the exact secret ARN, replace that wildcarded suffix with the exact
+ARN before applying the policy.
+
+## Review Checklist
+
+Before applying these policies:
+
+1. Confirm the secret already exists and uses the intended customer-managed KMS
+   key.
+2. Confirm the runtime role is dedicated to the TradeBot service environment.
+3. Confirm the runtime policy references one secret and one KMS key.
+4. Confirm no policy statement grants `secretsmanager:*`, `kms:*`, or resource
+   `"*"` for runtime secret or runtime KMS access.
+5. Confirm live trading gates remain disabled until the explicit permission
+   gate work lands.

--- a/deploy/aws/credential-custody/etrade-credential-kms-key-policy.json
+++ b/deploy/aws/credential-custody/etrade-credential-kms-key-policy.json
@@ -1,0 +1,67 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EnableAccountIamPermissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${AWS_ACCOUNT_ID}:root"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "AllowCredentialAdminsToManageKey",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${TRADEBOT_CREDENTIAL_ADMIN_ROLE_ARN}"
+      },
+      "Action": [
+        "kms:CancelKeyDeletion",
+        "kms:CreateAlias",
+        "kms:DeleteAlias",
+        "kms:DescribeKey",
+        "kms:DisableKey",
+        "kms:DisableKeyRotation",
+        "kms:EnableKey",
+        "kms:EnableKeyRotation",
+        "kms:GetKeyPolicy",
+        "kms:GetKeyRotationStatus",
+        "kms:ListAliases",
+        "kms:ListGrants",
+        "kms:ListKeyPolicies",
+        "kms:ListResourceTags",
+        "kms:PutKeyPolicy",
+        "kms:RevokeGrant",
+        "kms:ScheduleKeyDeletion",
+        "kms:TagResource",
+        "kms:UntagResource",
+        "kms:UpdateAlias",
+        "kms:UpdateKeyDescription"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "AllowRuntimeRoleToUseKeyThroughSecretsManager",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${TRADEBOT_RUNTIME_ROLE_ARN}"
+      },
+      "Action": [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "secretsmanager.${AWS_REGION}.amazonaws.com"
+        },
+        "StringLike": {
+          "kms:EncryptionContext:SecretARN": "arn:aws:secretsmanager:${AWS_REGION}:${AWS_ACCOUNT_ID}:secret:${TRADEBOT_ETRADE_SECRET_NAME}-*"
+        }
+      }
+    }
+  ]
+}

--- a/deploy/aws/credential-custody/etrade-runtime-secret-policy.json
+++ b/deploy/aws/credential-custody/etrade-runtime-secret-policy.json
@@ -1,0 +1,34 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ReadAndUpdateOneEtradeCredentialSecret",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:PutSecretValue"
+      ],
+      "Resource": "arn:aws:secretsmanager:${AWS_REGION}:${AWS_ACCOUNT_ID}:secret:${TRADEBOT_ETRADE_SECRET_NAME}-*"
+    },
+    {
+      "Sid": "UseCredentialKmsKeyThroughSecretsManager",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ],
+      "Resource": "arn:aws:kms:${AWS_REGION}:${AWS_ACCOUNT_ID}:key/${TRADEBOT_CREDENTIAL_KMS_KEY_ID}",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "secretsmanager.${AWS_REGION}.amazonaws.com"
+        },
+        "StringLike": {
+          "kms:EncryptionContext:SecretARN": "arn:aws:secretsmanager:${AWS_REGION}:${AWS_ACCOUNT_ID}:secret:${TRADEBOT_ETRADE_SECRET_NAME}-*"
+        }
+      }
+    }
+  ]
+}

--- a/docs/credential-trust-model.md
+++ b/docs/credential-trust-model.md
@@ -111,6 +111,11 @@ credential document as local development, but stores it as one JSON
 create secrets; secret creation, KMS key choice, IAM policy, and rotation policy
 belong to the infrastructure custody tickets.
 
+The starter AWS policies live under `deploy/aws/credential-custody/`. They are
+templates for one runtime role, one existing secret, and one customer-managed
+KMS key. The runtime role policy grants only `DescribeSecret`, `GetSecretValue`,
+`PutSecretValue`, and KMS key use through Secrets Manager for that secret.
+
 Expected secret document shape:
 
 ```json

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -94,7 +94,8 @@ Hosted AWS deployments can use
 credential document from an existing AWS Secrets Manager secret. The service
 role should be limited to the intended secret and the required read/write
 operations; KMS/IAM policy details are tracked separately from local Docker
-configuration.
+configuration. Starter policy templates live in
+`deploy/aws/credential-custody/`.
 
 `TRADEBOT_MOEX_SERVICE_ADAPTER_MODE` defaults to `local` for simple developer
 startup. When it is set to `http`, both `TRADEBOT_ORDERS_SERVICE_URL` and

--- a/tests/common/security/test_aws_credential_custody_policies.py
+++ b/tests/common/security/test_aws_credential_custody_policies.py
@@ -1,0 +1,126 @@
+import json
+from pathlib import Path
+
+
+POLICY_DIR = Path("deploy/aws/credential-custody")
+RUNTIME_POLICY = POLICY_DIR / "etrade-runtime-secret-policy.json"
+KMS_KEY_POLICY = POLICY_DIR / "etrade-credential-kms-key-policy.json"
+
+
+def test_runtime_policy_scopes_secret_and_kms_access():
+    # Given
+    # The runtime IAM policy template for hosted E*Trade credential custody.
+    policy = _load_policy(RUNTIME_POLICY)
+
+    # When
+    # The policy statements are inspected.
+    secret_statement = _statement(policy, "ReadAndUpdateOneEtradeCredentialSecret")
+    kms_statement = _statement(policy, "UseCredentialKmsKeyThroughSecretsManager")
+
+    # Then
+    # Runtime access is limited to the intended secret, key, and Secrets Manager path.
+    assert secret_statement["Action"] == [
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:PutSecretValue",
+    ]
+    assert secret_statement["Resource"] == (
+        "arn:aws:secretsmanager:${AWS_REGION}:${AWS_ACCOUNT_ID}:"
+        "secret:${TRADEBOT_ETRADE_SECRET_NAME}-*"
+    )
+    assert kms_statement["Resource"] == (
+        "arn:aws:kms:${AWS_REGION}:${AWS_ACCOUNT_ID}:key/${TRADEBOT_CREDENTIAL_KMS_KEY_ID}"
+    )
+    assert kms_statement["Condition"]["StringEquals"]["kms:ViaService"] == (
+        "secretsmanager.${AWS_REGION}.amazonaws.com"
+    )
+    assert kms_statement["Condition"]["StringLike"]["kms:EncryptionContext:SecretARN"] == (
+        secret_statement["Resource"]
+    )
+
+
+def test_runtime_policy_does_not_grant_secret_or_kms_administration():
+    # Given
+    # The runtime IAM policy template for the TradeBot service role.
+    policy = _load_policy(RUNTIME_POLICY)
+
+    # When
+    # All runtime actions and resources are inspected.
+    actions = {
+        action
+        for statement in policy["Statement"]
+        for action in _as_list(statement["Action"])
+    }
+    resources = [statement["Resource"] for statement in policy["Statement"]]
+
+    # Then
+    # The service cannot enumerate, create, delete, or broadly administer secrets or keys.
+    assert "secretsmanager:*" not in actions
+    assert "secretsmanager:CreateSecret" not in actions
+    assert "secretsmanager:DeleteSecret" not in actions
+    assert "secretsmanager:ListSecrets" not in actions
+    assert "secretsmanager:PutResourcePolicy" not in actions
+    assert "kms:*" not in actions
+    assert all(resource != "*" for resource in resources)
+
+
+def test_kms_key_policy_keeps_admin_and_runtime_roles_separate():
+    # Given
+    # The KMS key policy template for the credential key.
+    policy = _load_policy(KMS_KEY_POLICY)
+
+    # When
+    # The admin and runtime statements are inspected.
+    admin_statement = _statement(policy, "AllowCredentialAdminsToManageKey")
+    runtime_statement = _statement(policy, "AllowRuntimeRoleToUseKeyThroughSecretsManager")
+
+    # Then
+    # The admin role manages the key, while the runtime role performs data-key operations.
+    assert admin_statement["Principal"]["AWS"] == "${TRADEBOT_CREDENTIAL_ADMIN_ROLE_ARN}"
+    assert runtime_statement["Principal"]["AWS"] == "${TRADEBOT_RUNTIME_ROLE_ARN}"
+    assert "kms:Decrypt" not in admin_statement["Action"]
+    assert "kms:GenerateDataKey" not in admin_statement["Action"]
+    assert runtime_statement["Action"] == [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+    ]
+
+
+def test_kms_runtime_access_is_constrained_to_secrets_manager():
+    # Given
+    # The KMS key policy template for the credential key.
+    policy = _load_policy(KMS_KEY_POLICY)
+
+    # When
+    # Runtime key-use conditions are inspected.
+    runtime_statement = _statement(policy, "AllowRuntimeRoleToUseKeyThroughSecretsManager")
+
+    # Then
+    # The runtime role cannot use the key directly outside Secrets Manager.
+    assert runtime_statement["Condition"]["StringEquals"]["kms:ViaService"] == (
+        "secretsmanager.${AWS_REGION}.amazonaws.com"
+    )
+    assert runtime_statement["Condition"]["StringLike"]["kms:EncryptionContext:SecretARN"] == (
+        "arn:aws:secretsmanager:${AWS_REGION}:${AWS_ACCOUNT_ID}:"
+        "secret:${TRADEBOT_ETRADE_SECRET_NAME}-*"
+    )
+
+
+def _load_policy(path: Path) -> dict:
+    with open(path) as policy_file:
+        return json.load(policy_file)
+
+
+def _statement(policy: dict, sid: str) -> dict:
+    for statement in policy["Statement"]:
+        if statement["Sid"] == sid:
+            return statement
+    raise AssertionError(f"Missing policy statement {sid}")
+
+
+def _as_list(value) -> list:
+    if isinstance(value, list):
+        return value
+    return [value]


### PR DESCRIPTION
## Summary
- Add AWS credential-custody policy templates for one E*Trade Secrets Manager secret and one customer-managed KMS key.
- Document the runtime/admin role split, placeholder expectations, and review checklist.
- Add policy-shape tests that catch accidental runtime wildcarding, secret administration, and unconstrained KMS use.

## Ticket
- [FIA-174: Define AWS KMS and IAM policies for credential custody](https://linear.app/fianchetto-labs/issue/FIA-174/define-aws-kms-and-iam-policies-for-credential-custody)

## Verification
- `python -m json.tool deploy/aws/credential-custody/etrade-runtime-secret-policy.json`
- `python -m json.tool deploy/aws/credential-custody/etrade-credential-kms-key-policy.json`
- `.venv/bin/python -m pytest tests/common/security/test_aws_credential_custody_policies.py` - 4 passed
- `.venv/bin/python -m nox -s unit` - 248 passed, 39 deselected
- `git diff --check` - passed

## Notes
- These are policy templates, not a full Terraform/CDK stack.
- The runtime IAM policy is scoped to one secret ARN pattern and one KMS key ARN.
- The KMS key policy keeps key administration separate from runtime decrypt/data-key use, with runtime key use constrained through Secrets Manager and the credential secret encryption context.
