### PR TITLE
FIA-175: Add safe ETrade credential audit logs

### DIFF
--- a/docs/credential-trust-model.md
+++ b/docs/credential-trust-model.md
@@ -188,6 +188,8 @@ Allowed:
 - Environment/mode.
 - Request or correlation id.
 - Secret reference or version id when it is not itself sensitive.
+- Stable non-reversible secret fingerprints when the raw secret id could expose
+  account, client, environment, or naming details.
 - Redacted account reference, such as a stable alias or last-four style hint.
 - Result status, failure category, retry count, and upstream service name.
 
@@ -202,6 +204,13 @@ Forbidden:
 
 Error messages should explain the missing or invalid configuration field without
 printing the value.
+
+The E*Trade AWS Secrets Manager provider emits standard Python audit log lines
+to `fianchetto_tradebot.audit.credentials` for `GetSecretValue` and
+`PutSecretValue` calls. Those log lines include provider, operation, outcome,
+and a short SHA-256-based secret fingerprint. They do not include raw secret ids
+or credential payloads. Unexpected AWS read/write failures are raised as
+scrubbed operation-level errors for the same reason.
 
 ## Documentation And Demo Checklist
 

--- a/src/fianchetto_tradebot/server/common/brokerage/etrade/aws_credentials.py
+++ b/src/fianchetto_tradebot/server/common/brokerage/etrade/aws_credentials.py
@@ -1,4 +1,6 @@
+import hashlib
 import json
+import logging
 from json import JSONDecodeError
 from typing import Mapping, Protocol
 
@@ -6,6 +8,9 @@ from fianchetto_tradebot.server.common.brokerage.etrade.credentials import (
     ETradeConnectionCredentials,
     normalize_etrade_base_url,
 )
+
+
+audit_logger = logging.getLogger("fianchetto_tradebot.audit.credentials")
 
 
 class SecretsManagerClient(Protocol):
@@ -117,17 +122,27 @@ class ETradeAwsSecretsManagerCredentialProvider:
 
     def _get_secret_value(self) -> Mapping[str, object] | None:
         try:
-            return self._client.get_secret_value(SecretId=self.secret_id)
+            response = self._client.get_secret_value(SecretId=self.secret_id)
+            _log_secret_access("GetSecretValue", "success", self.secret_id)
+            return response
         except Exception as exc:
             if _is_resource_not_found_error(exc):
+                _log_secret_access("GetSecretValue", "missing", self.secret_id)
                 return None
-            raise
+            _log_secret_access("GetSecretValue", "failure", self.secret_id)
+            raise RuntimeError("E*Trade AWS credential secret read failed") from None
 
     def _store_secret_document(self, secret: Mapping[str, object]) -> None:
-        self._client.put_secret_value(
-            SecretId=self.secret_id,
-            SecretString=json.dumps(secret),
-        )
+        try:
+            self._client.put_secret_value(
+                SecretId=self.secret_id,
+                SecretString=json.dumps(secret),
+            )
+        except Exception:
+            _log_secret_access("PutSecretValue", "failure", self.secret_id)
+            raise RuntimeError("E*Trade AWS credential secret write failed") from None
+        else:
+            _log_secret_access("PutSecretValue", "success", self.secret_id)
 
 
 def _build_secrets_manager_client(
@@ -152,3 +167,17 @@ def _is_resource_not_found_error(exc: Exception) -> bool:
     if not isinstance(error, Mapping):
         return False
     return error.get("Code") == "ResourceNotFoundException"
+
+
+def _log_secret_access(operation: str, outcome: str, secret_id: str) -> None:
+    audit_logger.info(
+        "E*Trade credential secret access provider=aws_secrets_manager "
+        "operation=%s outcome=%s secret_ref=%s",
+        operation,
+        outcome,
+        _secret_reference(secret_id),
+    )
+
+
+def _secret_reference(secret_id: str) -> str:
+    return hashlib.sha256(secret_id.encode("utf-8")).hexdigest()[:12]

--- a/tests/common/api/etrade/test_etrade_aws_secrets_manager_credentials.py
+++ b/tests/common/api/etrade/test_etrade_aws_secrets_manager_credentials.py
@@ -1,4 +1,6 @@
+import hashlib
 import json
+import logging
 
 import pytest
 
@@ -12,6 +14,7 @@ from tests.fixtures.aws_secrets_manager import FakeSecretsManagerClient
 
 
 SECRET_ID = "tradebot/etrade/live/operator"
+AUDIT_LOGGER_NAME = "fianchetto_tradebot.audit.credentials"
 
 
 def test_aws_provider_loads_connection_credentials_from_secret_string():
@@ -195,6 +198,111 @@ def test_aws_provider_builds_secrets_manager_client_from_boto3_session():
     }
 
 
+def test_aws_provider_logs_safe_secret_read_audit_metadata(caplog):
+    # Given
+    # An AWS credential provider with a secret containing fake credential material.
+    caplog.set_level(logging.INFO, logger=AUDIT_LOGGER_NAME)
+    client = FakeSecretsManagerClient({SECRET_ID: json.dumps(_credentials_dict())})
+    provider = ETradeAwsSecretsManagerCredentialProvider(secret_id=SECRET_ID, client=client)
+
+    # When
+    # The provider reads the secret document.
+    provider.load()
+
+    # Then
+    # The audit log identifies the operation without printing the secret id or values.
+    assert "operation=GetSecretValue" in caplog.text
+    assert "outcome=success" in caplog.text
+    assert f"secret_ref={_expected_secret_reference(SECRET_ID)}" in caplog.text
+    _assert_no_secret_material_was_logged(caplog.text)
+
+
+def test_aws_provider_logs_safe_secret_write_audit_metadata(caplog):
+    # Given
+    # An AWS credential provider with a pre-created secret.
+    caplog.set_level(logging.INFO, logger=AUDIT_LOGGER_NAME)
+    client = FakeSecretsManagerClient({SECRET_ID: json.dumps(_credentials_dict())})
+    provider = ETradeAwsSecretsManagerCredentialProvider(secret_id=SECRET_ID, client=client)
+
+    # When
+    # The provider writes a new secret version.
+    provider.store(ETradeConnectionCredentials.from_mapping(_credentials_dict()))
+
+    # Then
+    # The audit log records the write without printing the secret id or payload.
+    assert "operation=PutSecretValue" in caplog.text
+    assert "outcome=success" in caplog.text
+    assert f"secret_ref={_expected_secret_reference(SECRET_ID)}" in caplog.text
+    _assert_no_secret_material_was_logged(caplog.text)
+
+
+def test_aws_provider_logs_missing_secret_without_leaking_secret_id(caplog):
+    # Given
+    # An AWS credential provider pointing at absent cloud state.
+    caplog.set_level(logging.INFO, logger=AUDIT_LOGGER_NAME)
+    provider = ETradeAwsSecretsManagerCredentialProvider(
+        secret_id=SECRET_ID,
+        client=FakeSecretsManagerClient(),
+    )
+
+    # When
+    # The provider checks for credentials.
+    assert provider.load() is None
+
+    # Then
+    # Missing state is auditable without exposing the configured secret name.
+    assert "operation=GetSecretValue" in caplog.text
+    assert "outcome=missing" in caplog.text
+    assert f"secret_ref={_expected_secret_reference(SECRET_ID)}" in caplog.text
+    _assert_no_secret_material_was_logged(caplog.text)
+
+
+def test_aws_provider_logs_secret_read_failure_without_exception_payload(caplog):
+    # Given
+    # A Secrets Manager client that fails with a non-missing upstream error.
+    class FailingReadClient(FakeSecretsManagerClient):
+        def get_secret_value(self, *, SecretId: str) -> dict[str, object]:
+            raise RuntimeError("upstream included simulator-consumer-secret")
+
+    caplog.set_level(logging.INFO, logger=AUDIT_LOGGER_NAME)
+    provider = ETradeAwsSecretsManagerCredentialProvider(
+        secret_id=SECRET_ID,
+        client=FailingReadClient(),
+    )
+
+    # When / Then
+    # The provider raises a scrubbed operation-level failure and keeps the audit line clean.
+    with pytest.raises(RuntimeError) as exc_info:
+        provider.load()
+    assert str(exc_info.value) == "E*Trade AWS credential secret read failed"
+    assert "simulator-consumer-secret" not in str(exc_info.value)
+    assert "operation=GetSecretValue" in caplog.text
+    assert "outcome=failure" in caplog.text
+    _assert_no_secret_material_was_logged(caplog.text)
+
+
+def test_aws_provider_logs_secret_write_failure_without_secret_payload(caplog):
+    # Given
+    # A Secrets Manager client that rejects writes after seeing the payload.
+    class FailingWriteClient(FakeSecretsManagerClient):
+        def put_secret_value(self, *, SecretId: str, SecretString: str) -> dict[str, object]:
+            raise RuntimeError("write failed for secret payload")
+
+    caplog.set_level(logging.INFO, logger=AUDIT_LOGGER_NAME)
+    client = FailingWriteClient({SECRET_ID: json.dumps(_credentials_dict())})
+    provider = ETradeAwsSecretsManagerCredentialProvider(secret_id=SECRET_ID, client=client)
+
+    # When / Then
+    # The write failure is auditable without logging the credential payload.
+    with pytest.raises(RuntimeError) as exc_info:
+        provider.store(ETradeConnectionCredentials.from_mapping(_credentials_dict()))
+    assert str(exc_info.value) == "E*Trade AWS credential secret write failed"
+    assert "simulator-consumer-secret" not in str(exc_info.value)
+    assert "operation=PutSecretValue" in caplog.text
+    assert "outcome=failure" in caplog.text
+    _assert_no_secret_material_was_logged(caplog.text)
+
+
 def _credentials_dict(**overrides) -> dict[str, object]:
     credentials = {
         "consumer_key": "simulator-consumer-key",
@@ -207,3 +315,17 @@ def _credentials_dict(**overrides) -> dict[str, object]:
     }
     credentials.update(overrides)
     return credentials
+
+
+def _assert_no_secret_material_was_logged(log_text: str) -> None:
+    assert SECRET_ID not in log_text
+    assert "simulator-consumer-key" not in log_text
+    assert "simulator-consumer-secret" not in log_text
+    assert "simulator-access-token" not in log_text
+    assert "simulator-access-token-secret" not in log_text
+    assert "simulator-request-token" not in log_text
+    assert "simulator-request-token-secret" not in log_text
+
+
+def _expected_secret_reference(secret_id: str) -> str:
+    return hashlib.sha256(secret_id.encode("utf-8")).hexdigest()[:12]


### PR DESCRIPTION
## Summary
- Add safe audit log lines around E*Trade AWS Secrets Manager read/write calls.
- Log provider, operation, outcome, and a short SHA-256-based secret fingerprint instead of raw secret ids or credential values.
- Wrap unexpected AWS secret read/write failures with scrubbed operation-level errors.
- Document the credential audit-log convention.

## Ticket
- [FIA-175: Add safe audit logging for secret and brokerage access](https://linear.app/fianchetto-labs/issue/FIA-175/add-safe-audit-logging-for-secret-and-brokerage-access)

## Verification
- `.venv/bin/python -m nox -s test -- tests/common/api/etrade/test_etrade_aws_secrets_manager_credentials.py` - 15 passed
- `.venv/bin/python -m nox -s unit` - 253 passed, 39 deselected
- `git diff --check` - passed

## Notes
- This intentionally stays narrow: standard Python logging in the AWS credential provider only, no generic audit framework.
- Brokerage action audit coverage remains separate follow-up work; this PR only covers the implemented Secrets Manager credential boundary.
