### PR TITLE
FIA-176: Gate live ETrade writes

### DIFF
--- a/docs/credential-trust-model.md
+++ b/docs/credential-trust-model.md
@@ -177,6 +177,12 @@ Live placement, cancellation, and modification should require explicit runtime
 gates and account/operation authorization. They should never be enabled merely
 because credentials are present.
 
+The current E*Trade live-write gate is intentionally small and fail-closed:
+`ETradeOrderService` blocks placement, cancellation, and modification against
+`https://api.etrade.com` unless `TRADEBOT_ALLOW_LIVE_ETRADE_WRITES=true` is set
+in the runtime environment. Preview, read-only, and simulator-backed endpoints
+do not require this flag.
+
 ## Logging And Display Rules
 
 Safe logs should answer what happened without becoming a credential leak.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -85,6 +85,7 @@ Important runtime configuration:
 | --- | --- |
 | `FIANCHETTO_TRADEBOT_STATE_DIR` | Points a service at its credential/state directory. |
 | `TRADEBOT_ETRADE_API_BASE_URL` | Overrides the E*Trade-compatible API endpoint, commonly to the simulator service in Docker. |
+| `TRADEBOT_ALLOW_LIVE_ETRADE_WRITES` | Must be `true` before live E*Trade place/cancel/modify calls are allowed against `https://api.etrade.com`. |
 | `TRADEBOT_MOEX_SERVICE_ADAPTER_MODE` | Selects local vs HTTP-backed MOEX dependencies. |
 | `TRADEBOT_ORDERS_SERVICE_URL` | Tells MOEX where the orders service lives in HTTP mode. |
 | `TRADEBOT_QUOTES_SERVICE_URL` | Tells MOEX where the quotes service lives in HTTP mode. |

--- a/src/fianchetto_tradebot/server/common/api/orders/etrade/etrade_order_service.py
+++ b/src/fianchetto_tradebot/server/common/api/orders/etrade/etrade_order_service.py
@@ -27,6 +27,7 @@ from fianchetto_tradebot.common_models.api.orders.preview_order_response import 
 from fianchetto_tradebot.common_models.api.request_status import RequestStatus
 from fianchetto_tradebot.server.common.api.http_status_code import HttpStatusCode
 from fianchetto_tradebot.server.common.api.orders.order_util import OrderUtil
+from fianchetto_tradebot.server.common.api.orders.etrade.live_trading_gate import require_live_etrade_write_enabled
 from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import ETradeConnector
 from fianchetto_tradebot.common_models.finance.amount import Amount
 from fianchetto_tradebot.common_models.order.order import Order
@@ -84,6 +85,8 @@ class ETradeOrderService(OrderService):
         return ETradeOrderService._parse_get_order_response(response, account_id, order_id)
 
     def cancel_order(self, cancel_order_request: CancelOrderRequest) -> CancelOrderResponse:
+        require_live_etrade_write_enabled(self.base_url, "cancel_order")
+
         account_id = cancel_order_request.account_id
         order_id = cancel_order_request.order_id
 
@@ -159,6 +162,8 @@ class ETradeOrderService(OrderService):
         return preview_order_response
 
     def place_modify_order(self, place_modify_order_request: PlaceModifyOrderRequest) -> PlaceModifyOrderResponse:
+        require_live_etrade_write_enabled(self.base_url, "place_modify_order")
+
         order_metadata = place_modify_order_request.order_metadata
         order_type = order_metadata.order_type
         account_id = order_metadata.account_id
@@ -196,6 +201,8 @@ class ETradeOrderService(OrderService):
         return ETradeOrderService._parse_place_order_response(response, order_metadata, preview_id)
 
     def place_order(self, place_order_request: PlaceOrderRequest) -> PlaceOrderResponse:
+        require_live_etrade_write_enabled(self.base_url, "place_order")
+
         order_metadata = place_order_request.order_metadata
         order_type = order_metadata.order_type
         account_id = order_metadata.account_id
@@ -231,6 +238,8 @@ class ETradeOrderService(OrderService):
         return ETradeOrderService._parse_place_order_response(response, order_metadata, preview_id)
 
     def preview_and_place_order(self, preview_order_request: PreviewOrderRequest) -> PlaceOrderResponse:
+        require_live_etrade_write_enabled(self.base_url, "preview_and_place_order")
+
         order_metadata = preview_order_request.order_metadata
         preview_order_response: PreviewOrderResponse = self.preview_order(preview_order_request)
 
@@ -241,6 +250,8 @@ class ETradeOrderService(OrderService):
         return place_order_response
 
     def modify_order(self, preview_modify_order_request: PreviewModifyOrderRequest) -> PlaceOrderResponse:
+        require_live_etrade_write_enabled(self.base_url, "modify_order")
+
         # Cancel
         account_id = preview_modify_order_request.order_metadata.account_id
         order_id = preview_modify_order_request.order_id_to_modify

--- a/src/fianchetto_tradebot/server/common/api/orders/etrade/live_trading_gate.py
+++ b/src/fianchetto_tradebot/server/common/api/orders/etrade/live_trading_gate.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from urllib.parse import urlparse
+
+ETRADE_LIVE_WRITES_ENABLED_ENV_VAR = "TRADEBOT_ALLOW_LIVE_ETRADE_WRITES"
+LIVE_ETRADE_HOSTS = {"api.etrade.com"}
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def require_live_etrade_write_enabled(
+    base_url: str,
+    operation: str,
+    env: Mapping[str, str] | None = None,
+) -> None:
+    if not _is_live_etrade_base_url(base_url):
+        return
+
+    env = env if env is not None else os.environ
+    if env.get(ETRADE_LIVE_WRITES_ENABLED_ENV_VAR, "").strip().lower() in TRUE_VALUES:
+        return
+
+    raise PermissionError(
+        f"Live E*Trade {operation} is disabled. "
+        f"Set {ETRADE_LIVE_WRITES_ENABLED_ENV_VAR}=true to enable live brokerage writes."
+    )
+
+
+def _is_live_etrade_base_url(base_url: str) -> bool:
+    parsed_url = urlparse(base_url)
+    return parsed_url.hostname in LIVE_ETRADE_HOSTS

--- a/tests/common/api/orders/etrade/test_etrade_order_service.py
+++ b/tests/common/api/orders/etrade/test_etrade_order_service.py
@@ -5,12 +5,17 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from fianchetto_tradebot.server.common.api.orders.etrade.etrade_order_service import ETradeOrderService
 from fianchetto_tradebot.common_models.api.orders.order_metadata import OrderMetadata
+from fianchetto_tradebot.common_models.api.orders.cancel_order_request import CancelOrderRequest
+from fianchetto_tradebot.common_models.api.orders.place_modify_order_request import PlaceModifyOrderRequest
+from fianchetto_tradebot.common_models.api.orders.place_order_request import PlaceOrderRequest
 from fianchetto_tradebot.common_models.api.orders.place_order_response import PlaceOrderResponse
+from fianchetto_tradebot.common_models.api.orders.preview_modify_order_request import PreviewModifyOrderRequest
 from fianchetto_tradebot.common_models.api.orders.preview_order_request import PreviewOrderRequest
 from fianchetto_tradebot.common_models.api.orders.preview_order_response import PreviewOrderResponse
 from fianchetto_tradebot.server.common.api.http_status_code import HttpStatusCode
+from fianchetto_tradebot.server.common.api.orders.etrade.etrade_order_service import ETradeOrderService
+from fianchetto_tradebot.server.common.api.orders.etrade.live_trading_gate import ETRADE_LIVE_WRITES_ENABLED_ENV_VAR
 from fianchetto_tradebot.server.common.brokerage.etrade.etrade_connector import ETradeConnector, DEFAULT_ETRADE_BASE_URL_FILE
 from fianchetto_tradebot.common_models.finance.amount import Amount
 from fianchetto_tradebot.common_models.order.executed_order import ExecutedOrder
@@ -35,6 +40,7 @@ EXPECTED_ORDER_PRICE = OrderPrice(order_price_type=OrderPriceType.NET_CREDIT, pr
 
 PLACED_ORDER_ID = 81117
 FAKE_ETRADE_BASE_URL = "https://api.example.test"
+LIVE_ETRADE_BASE_URL = "https://api.etrade.com"
 
 SPREAD_PREVIEW_ORDER_RESPONSE_FILE = os.path.join(os.path.dirname(__file__), "./resources/output_preview_order_spread")
 SPREAD_PLACE_ORDER_RESPONSE_FILE = os.path.join(os.path.dirname(__file__), "./resources/output_place_order_spread")
@@ -64,16 +70,151 @@ def place_order_spread_response():
 
 @pytest.fixture
 def connector():
-    session = MagicMock()
-    async_session = MagicMock()
-    connector = MagicMock(spec=ETradeConnector)
-    connector.load_connection.return_value = (session, async_session, FAKE_ETRADE_BASE_URL)
-    return connector
+    return _connector_with_base_url(FAKE_ETRADE_BASE_URL)
 
 @pytest.fixture
 def order_service(connector):
     # TODO: Set up the service that will provide mock responses to given requests
     return ETradeOrderService(connector)
+
+
+def test_live_place_order_fails_closed_without_runtime_gate(monkeypatch):
+    # Given
+    # A service pointed at the live E*Trade API without the explicit write gate.
+    monkeypatch.delenv(ETRADE_LIVE_WRITES_ENABLED_ENV_VAR, raising=False)
+    order_service = ETradeOrderService(_connector_with_base_url(LIVE_ETRADE_BASE_URL))
+    place_request = PlaceOrderRequest(
+        order_metadata=SPREAD_ORDER_METADATA,
+        preview_id=SPREAD_ORDER_PREVIEW_ID,
+        order=SPREAD_ORDER,
+    )
+
+    # When / Then
+    # The service rejects the live write before it reaches the brokerage session.
+    with pytest.raises(PermissionError) as exc_info:
+        order_service.place_order(place_request)
+
+    assert "place_order" in str(exc_info.value)
+    assert ETRADE_LIVE_WRITES_ENABLED_ENV_VAR in str(exc_info.value)
+    assert ACCOUNT_ID not in str(exc_info.value)
+    assert SPREAD_ORDER_PREVIEW_ID not in str(exc_info.value)
+    order_service.session.post.assert_not_called()
+
+
+def test_live_cancel_order_fails_closed_without_runtime_gate(monkeypatch):
+    # Given
+    # A service pointed at the live E*Trade API without the explicit write gate.
+    monkeypatch.delenv(ETRADE_LIVE_WRITES_ENABLED_ENV_VAR, raising=False)
+    order_service = ETradeOrderService(_connector_with_base_url(LIVE_ETRADE_BASE_URL))
+
+    # When / Then
+    # Cancellation is also blocked because it can change live trading outcomes.
+    with pytest.raises(PermissionError) as exc_info:
+        order_service.cancel_order(CancelOrderRequest(account_id=ACCOUNT_ID, order_id=str(PLACED_ORDER_ID)))
+
+    assert "cancel_order" in str(exc_info.value)
+    assert ACCOUNT_ID not in str(exc_info.value)
+    assert str(PLACED_ORDER_ID) not in str(exc_info.value)
+    order_service.session.put.assert_not_called()
+
+
+def test_live_modify_order_fails_closed_before_canceling_original_order(monkeypatch):
+    # Given
+    # A live modify request that would cancel and replace the original order.
+    monkeypatch.delenv(ETRADE_LIVE_WRITES_ENABLED_ENV_VAR, raising=False)
+    order_service = ETradeOrderService(_connector_with_base_url(LIVE_ETRADE_BASE_URL))
+    modify_request = PreviewModifyOrderRequest(
+        order_metadata=SPREAD_ORDER_METADATA,
+        order_id_to_modify=str(PLACED_ORDER_ID),
+        order=SPREAD_ORDER,
+    )
+
+    # When / Then
+    # The guard rejects the modify operation before the internal cancel path runs.
+    with pytest.raises(PermissionError) as exc_info:
+        order_service.modify_order(modify_request)
+
+    assert "modify_order" in str(exc_info.value)
+    order_service.session.put.assert_not_called()
+    order_service.session.post.assert_not_called()
+
+
+def test_live_place_modify_order_fails_closed_without_runtime_gate(monkeypatch):
+    # Given
+    # A direct place-modify call against the live E*Trade API.
+    monkeypatch.delenv(ETRADE_LIVE_WRITES_ENABLED_ENV_VAR, raising=False)
+    order_service = ETradeOrderService(_connector_with_base_url(LIVE_ETRADE_BASE_URL))
+    place_modify_request = PlaceModifyOrderRequest(
+        order_metadata=SPREAD_ORDER_METADATA,
+        order_id_to_modify=str(PLACED_ORDER_ID),
+        preview_id=SPREAD_ORDER_PREVIEW_ID,
+        order=SPREAD_ORDER,
+    )
+
+    # When / Then
+    # The service rejects the live write before it reaches the brokerage session.
+    with pytest.raises(PermissionError) as exc_info:
+        order_service.place_modify_order(place_modify_request)
+
+    assert "place_modify_order" in str(exc_info.value)
+    order_service.session.put.assert_not_called()
+
+
+def test_live_preview_and_place_order_fails_closed_before_preview(monkeypatch, spread_preview_request):
+    # Given
+    # A combined preview-and-place request against the live E*Trade API.
+    monkeypatch.delenv(ETRADE_LIVE_WRITES_ENABLED_ENV_VAR, raising=False)
+    order_service = ETradeOrderService(_connector_with_base_url(LIVE_ETRADE_BASE_URL))
+
+    # When / Then
+    # The service rejects the operation before sending the preview request.
+    with pytest.raises(PermissionError) as exc_info:
+        order_service.preview_and_place_order(spread_preview_request)
+
+    assert "preview_and_place_order" in str(exc_info.value)
+    order_service.session.post.assert_not_called()
+
+
+def test_live_place_order_runs_when_runtime_gate_is_explicitly_enabled(monkeypatch, place_order_spread_response):
+    # Given
+    # A live service with the explicit write gate enabled.
+    monkeypatch.setenv(ETRADE_LIVE_WRITES_ENABLED_ENV_VAR, "true")
+    order_service = ETradeOrderService(_connector_with_base_url(LIVE_ETRADE_BASE_URL))
+    order_service.session.post.return_value = place_order_spread_response
+
+    # When
+    response = order_service.place_order(
+        PlaceOrderRequest(
+            order_metadata=SPREAD_ORDER_METADATA,
+            preview_id=SPREAD_ORDER_PREVIEW_ID,
+            order=SPREAD_ORDER,
+        )
+    )
+
+    # Then
+    assert response.order_id == str(PLACED_ORDER_ID)
+    order_service.session.post.assert_called_once()
+
+
+def test_non_live_place_order_does_not_require_runtime_gate(monkeypatch, place_order_spread_response):
+    # Given
+    # A simulator or test endpoint, where writes do not touch the live broker.
+    monkeypatch.delenv(ETRADE_LIVE_WRITES_ENABLED_ENV_VAR, raising=False)
+    order_service = ETradeOrderService(_connector_with_base_url("http://etrade-sim:8090"))
+    order_service.session.post.return_value = place_order_spread_response
+
+    # When
+    response = order_service.place_order(
+        PlaceOrderRequest(
+            order_metadata=SPREAD_ORDER_METADATA,
+            preview_id=SPREAD_ORDER_PREVIEW_ID,
+            order=SPREAD_ORDER,
+        )
+    )
+
+    # Then
+    assert response.order_id == str(PLACED_ORDER_ID)
+    order_service.session.post.assert_called_once()
 
 def test_process_spread_preview_order_response(preview_order_spread_response):
     response: PreviewOrderResponse = ETradeOrderService._parse_preview_order_response(preview_order_spread_response, SPREAD_ORDER_METADATA)
@@ -220,6 +361,14 @@ def _read_input(input_file):
     with open(input_file, 'rb') as handle:
         response = pickle.load(handle)
     return response
+
+
+def _connector_with_base_url(base_url: str):
+    session = MagicMock()
+    async_session = MagicMock()
+    connector = MagicMock(spec=ETradeConnector)
+    connector.load_connection.return_value = (session, async_session, base_url)
+    return connector
 
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
Ticket:
- https://linear.app/fianchetto-labs/issue/FIA-176/add-explicit-live-trading-permission-gates

Summary:
- Add a fail-closed runtime gate for live E*Trade place, place-modify, preview-and-place, modify, and cancel calls.
- Keep preview/read-only and simulator-backed endpoints outside the live-write gate.
- Document TRADEBOT_ALLOW_LIVE_ETRADE_WRITES in the credential trust model and deployment docs.

Verification:
- .venv/bin/python -m pytest tests/common/api/orders/etrade/test_etrade_order_service.py tests/common/api/etrade_simulator/test_etrade_simulator_contract.py
- .venv/bin/python -m nox -s unit
- .venv/bin/python -m nox -s functional

Security:
- Live E*Trade writes now fail closed unless TRADEBOT_ALLOW_LIVE_ETRADE_WRITES=true is set.
- Denial messages include the operation and env var name, but not account ids, preview ids, order ids, credentials, or order payloads.

Scope:
- This intentionally does not add client grants, role-based authorization, intake, rotation, or revocation. Those stay in FIA-177/FIA-178/FIA-179.